### PR TITLE
:bento: add license file to /licenses/vllm.md

### DIFF
--- a/Dockerfile.ubi
+++ b/Dockerfile.ubi
@@ -304,5 +304,7 @@ RUN microdnf install -y shadow-utils \
     && microdnf clean all \
     && chmod g+rwx $HOME /usr/src /workspace
 
+COPY LICENSE /licenses/vllm.md
+
 USER 2000
 ENTRYPOINT ["python3", "-m", "vllm.entrypoints.openai.api_server"]


### PR DESCRIPTION
Had a user request for the apache 2 license file to exist in the image we provide