### PR TITLE
Implement the length penalty using a logit processor

### DIFF
--- a/vllm/entrypoints/grpc/validation.py
+++ b/vllm/entrypoints/grpc/validation.py
@@ -33,7 +33,6 @@ class TGISValidationError(str, Enum):
     SampleParametersGreedy = "sampling parameters aren't applicable in greedy decoding mode"
 
     # Additions that are _not_ in TGIS
-    LengthPenaltyUnsupported = "decoding.length_penalty parameter not yet supported"
     TopN = "top_n_tokens ({0}) must be <= {1}"
 
     def error(self, *args, **kwargs):
@@ -62,9 +61,8 @@ def validate_params(params: Parameters, max_max_new_tokens: int):
 
     # Decoding parameter checks
     if decoding.HasField("length_penalty"):
-        # TODO: remove this when we support length penalty
-        TGISValidationError.LengthPenaltyUnsupported.error()
-        if not (1.0 <= decoding.length_penalty.decay_factor <= 10.0):
+        args = [decoding.length_penalty.decay_factor, decoding.length_penalty.decay_factor]
+        if None in args or args[0] < 1.0 or args[1] > 10.0:
             TGISValidationError.LengthPenalty.error()
 
     if not(0 <= decoding.repetition_penalty <= 2):

--- a/vllm/sampling_params.py
+++ b/vllm/sampling_params.py
@@ -2,7 +2,7 @@
 import copy
 from enum import IntEnum
 from functools import cached_property
-from typing import Callable, List, Optional, Union
+from typing import Callable, List, Optional, Tuple, Union
 
 import torch
 

--- a/vllm/tgis_utils/logits_processors.py
+++ b/vllm/tgis_utils/logits_processors.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Tuple
 
 import torch
 from transformers.generation.logits_process import TypicalLogitsWarper
@@ -14,3 +14,17 @@ class TypicalLogitsWarperWrapper:
         # transformers warpers assume tensors of shape (batch_size, vocab_size)
         # and the typical warper doesn't use input_ids
         return self.warper(input_ids=None, scores=logits.reshape((1, -1)))
+
+
+class LengthPenaltyWarper:
+
+    def __init__(self, length_penalty: Tuple[int,float], eos_token_id: int):
+        self.length_penalty = length_penalty
+        self.eos_token_id = eos_token_id
+
+    def __call__(self, token_ids: List[int],
+                 logits: torch.tensor) -> torch.tensor:
+        tokens_past = len(token_ids) - self.length_penalty[0]
+        if tokens_past > 0:
+            logits[self.eos_token_id] *=  pow(self.length_penalty[1], tokens_past)
+        return logits


### PR DESCRIPTION
This implementation is simpler than changing the sampler code and less invasive in the core vllm code.

