### PR TITLE
:loud_sound: Add TGIS response logs

### DIFF
--- a/vllm/entrypoints/grpc/grpc_server.py
+++ b/vllm/entrypoints/grpc/grpc_server.py
@@ -133,10 +133,10 @@ class TextGenerationService(generation_pb2_grpc.GenerationServiceServicer):
         output_len = len(res.text)
         short_output = self.truncate(res.text, 32)
         short_input = [self.truncate(r.text, 32) for r in req.requests]
-        input_bytes = sum(len(r.text) for r in req.requests)
+        input_chars = sum(len(r.text) for r in req.requests)
 
         paramstr = text_format.MessageToString(req.params, as_one_line=True)
-        span_str = f"generate{{input={short_input} prefix_id={req.prefix_id} input_bytes=[{input_bytes}] params={paramstr} tokenization_time={tokenization_time*1e3:.2f}ms queue_and_inference_time={llm_engine_time*1e3:.2f}ms time_per_token={time_per_token*1e3:.2f}ms total_time={total_time*1e3:.2f}ms input_toks={res.input_token_count}}}"
+        span_str = f"generate{{input={short_input} prefix_id={req.prefix_id} input_chars=[{input_chars}] params={paramstr} tokenization_time={tokenization_time*1e3:.2f}ms queue_and_inference_time={llm_engine_time*1e3:.2f}ms time_per_token={time_per_token*1e3:.2f}ms total_time={total_time*1e3:.2f}ms input_toks={res.input_token_count}}}"
         stop_reason_str = StopReason.Name(res.stop_reason)
 
         if res.stop_reason == StopReason.ERROR:

--- a/vllm/entrypoints/grpc/grpc_server.py
+++ b/vllm/entrypoints/grpc/grpc_server.py
@@ -546,7 +546,7 @@ class TextGenerationService(generation_pb2_grpc.GenerationServiceServicer):
     @staticmethod
     def _log_streaming_response(request: SingleGenerationRequest,
                                 response: GenerationResponse, times: Times):
-        logs.log_response(inputs=[request.text], response=response,
+        logs.log_response(inputs=[request.request.text], response=response,
                           params=request.params, prefix_id=request.prefix_id,
                           times=times, kind_log="Streaming response",
                           method_str="generate_stream", logger=logger)

--- a/vllm/entrypoints/grpc/grpc_server.py
+++ b/vllm/entrypoints/grpc/grpc_server.py
@@ -107,8 +107,7 @@ class TextGenerationService(generation_pb2_grpc.GenerationServiceServicer):
     # TODO move and clean up all this junk :D
     def truncate(self, text: str, len_: int) -> bytes:
         """Truncates a string and escapes control characters"""
-        if len(text) > len_:
-            return f"{text:.{len_}}...".encode("unicode_escape")
+        text = f"{text:.{len_}}..." if len(text) > len_ else text
         return text.encode("unicode_escape")
 
     @staticmethod

--- a/vllm/entrypoints/grpc/grpc_server.py
+++ b/vllm/entrypoints/grpc/grpc_server.py
@@ -113,7 +113,7 @@ class TextGenerationService(generation_pb2_grpc.GenerationServiceServicer):
                 = await self._validate_prompt_and_tokenize(
                     sampling_params, truncate_input_tokens, req.text, context)
             generators.append(
-                self.engine.generate(None,
+                self.engine.generate(req.text,
                                      sampling_params,
                                      f"{request_id}-{i}",
                                      prompt_token_ids=input_ids))
@@ -166,7 +166,7 @@ class TextGenerationService(generation_pb2_grpc.GenerationServiceServicer):
             context)
 
         result_generator = self.engine.generate(
-            prompt=None,
+            prompt=request.request.text,
             sampling_params=sampling_params,
             request_id=request_id,
             prompt_token_ids=input_ids,

--- a/vllm/entrypoints/grpc/grpc_server.py
+++ b/vllm/entrypoints/grpc/grpc_server.py
@@ -214,7 +214,6 @@ class TextGenerationService(generation_pb2_grpc.GenerationServiceServicer):
         last_token_count = 0
         time_limit_reached = False
         full_output = ""
-        full_output_token_count = 0
         #TODO handle cancellation
         #TODO: Time and log
         async for result in result_generator:
@@ -244,14 +243,13 @@ class TextGenerationService(generation_pb2_grpc.GenerationServiceServicer):
             last_token_count = len(output.token_ids)
             # Accumulate full output for logging
             full_output += output.text
-            full_output_token_count += last_token_count
 
         # Edit up the first_response for logging purposes only
         if first_response is None:
             # We didn't output anything!
             return
         first_response.text = full_output
-        first_response.generated_token_count = full_output_token_count
+        first_response.generated_token_count = last_token_count
         self._log_streaming_response(request=request, response=first_response,
                                      times=timing_info)
 

--- a/vllm/entrypoints/grpc/grpc_server.py
+++ b/vllm/entrypoints/grpc/grpc_server.py
@@ -1,6 +1,7 @@
 import argparse
 import dataclasses
 import inspect
+import logging
 import time
 import uuid
 from typing import (Any, AsyncIterator, Dict, List, MutableSequence, Optional,
@@ -139,13 +140,12 @@ class TextGenerationService(generation_pb2_grpc.GenerationServiceServicer):
         stop_reason_str = StopReason.Name(res.stop_reason)
 
         if res.stop_reason == StopReason.ERROR:
-            log_method = logger.error
+            level = logging.ERROR
         elif res.stop_reason in {StopReason.CANCELLED, StopReason.TOKEN_LIMIT}:
-            log_method = logger.warning
+            level = logging.WARN
         else:
-            log_method = logger.info
-
-        log_method(f"{span_str}: {kind_log} generated {res.generated_token_count} tokens before {stop_reason_str}, output {output_len} bytes: {short_output}")
+            level = logging.INFO
+        logger.log(level, f"{span_str}: {kind_log} generated {res.generated_token_count} tokens before {stop_reason_str}, output {output_len} bytes: {short_output}")
 
     def safe_div(self, a: float, b: float, *, default: float) -> float:
         try:

--- a/vllm/entrypoints/grpc/grpc_server.py
+++ b/vllm/entrypoints/grpc/grpc_server.py
@@ -210,14 +210,15 @@ class TextGenerationService(generation_pb2_grpc.GenerationServiceServicer):
             response = self._convert_output(res.outputs[0], resp_options,
                                             max_is_token_limit[i],
                                             time_limit_reached)
-            responses[i] = self._convert_input_details(res, resp_options,
+            response = self._convert_input_details(res, resp_options,
                                                        sampling_params,
                                                        response)
             if request_count == 1:
                 kind_log = "Request"
             else:
                 kind_log = f"Sub-request {i} from batch of {request_count}"
-            self.log_response(req=request, res=responses[i], times=timing_infos[i], kind_log=kind_log)
+            self.log_response(req=request, res=response, times=timing_infos[i], kind_log=kind_log)
+            responses[i] = response
 
         return BatchedGenerationResponse(responses=responses)
 

--- a/vllm/entrypoints/grpc/grpc_server.py
+++ b/vllm/entrypoints/grpc/grpc_server.py
@@ -160,8 +160,6 @@ class TextGenerationService(generation_pb2_grpc.GenerationServiceServicer):
                 break
 
         for i, res in enumerate(responses):
-            # Text prompt is not returned if only token_ids are passed
-            res.prompt = request.requests[i].text
             response = self._convert_output(res.outputs[0], resp_options,
                                             max_is_token_limit[i],
                                             time_limit_reached)
@@ -215,11 +213,8 @@ class TextGenerationService(generation_pb2_grpc.GenerationServiceServicer):
         time_limit_reached = False
         full_output = ""
         #TODO handle cancellation
-        #TODO: Time and log
         async for result in result_generator:
             if first:
-                # Text prompt is not returned if only token_ids are passed
-                result.prompt = request.request.text
                 first_response = self._convert_input_details(
                     result, resp_options, sampling_params,
                     GenerationResponse())

--- a/vllm/entrypoints/grpc/grpc_server.py
+++ b/vllm/entrypoints/grpc/grpc_server.py
@@ -236,8 +236,8 @@ class TextGenerationService(generation_pb2_grpc.GenerationServiceServicer):
 
             last_output_length = len(output.text)
             last_token_count = len(output.token_ids)
-            # Accumulate full output for logging
-            full_output += output.text
+            # Save full output for logging
+            full_output = output.text
 
         # Edit up the first_response for logging purposes only
         if first_response is None:

--- a/vllm/entrypoints/grpc/grpc_server.py
+++ b/vllm/entrypoints/grpc/grpc_server.py
@@ -213,10 +213,10 @@ class TextGenerationService(generation_pb2_grpc.GenerationServiceServicer):
             responses[i] = self._convert_input_details(res, resp_options,
                                                        sampling_params,
                                                        response)
-            if len(request.requests) == 1:
+            if request_count == 1:
                 kind_log = "Request"
             else:
-                kind_log = f"Sub-request {i} from batch of {len(request.requests)}"
+                kind_log = f"Sub-request {i} from batch of {request_count}"
             self.log_response(req=request, res=responses[i], times=timing_infos[i], kind_log=kind_log)
 
         return BatchedGenerationResponse(responses=responses)

--- a/vllm/tgis_utils/args.py
+++ b/vllm/tgis_utils/args.py
@@ -114,5 +114,9 @@ def postprocess_tgis_args(args: argparse.Namespace) -> argparse.Namespace:
     if args.max_logprobs < MAX_TOP_N_TOKENS + 1:
         logger.info("Setting max_logprobs to %d", MAX_TOP_N_TOKENS + 1)
         args.max_logprobs = MAX_TOP_N_TOKENS + 1
+    # Turn off vLLM per-request logging because the TGIS server logs each
+    # response
+    if not args.disable_log_requests:
+        args.disable_log_requests = True
 
     return args

--- a/vllm/tgis_utils/logs.py
+++ b/vllm/tgis_utils/logs.py
@@ -1,0 +1,68 @@
+"""Some methods for producing logs similar to TGIS"""
+import logging
+from typing import List
+
+from google.protobuf import text_format
+
+from vllm.entrypoints.grpc.pb.generation_pb2 import StopReason, Parameters
+
+
+def log_response(inputs: List[str],
+                 output: str,
+                 params: Parameters,
+                 prefix_id: str,
+                 input_token_count: int,
+                 generated_token_count: int,
+                 stop_reason: StopReason,
+                 times: 'Times',
+                 kind_log: str,
+                 method_str: str,
+                 logger: logging.Logger):
+    """Logs responses similar to how the TGIS server does"""
+    # This contains both request validation and tokenization
+    tokenization_time = times.engine_start - times.request_start
+    llm_engine_time = times.end - times.engine_start
+    time_per_token = _safe_div(llm_engine_time, generated_token_count)
+    total_time = times.request_start - times.end
+    output_len = len(output)
+    short_output = _truncate(output, 32)
+    short_input = [_truncate(input_, 32) for input_ in inputs]
+    input_chars = sum(len(input_) for input_ in inputs)
+
+    paramstr = text_format.MessageToString(params, as_one_line=True)
+    span_str = (f"{method_str}{{input={short_input} prefix_id={prefix_id} "
+                f"input_chars=[{input_chars}] params={paramstr} "
+                f"tokenization_time={tokenization_time * 1e3:.2f}ms "
+                f"queue_and_inference_time={llm_engine_time * 1e3:.2f}ms "
+                f"time_per_token={time_per_token * 1e3:.2f}ms "
+                f"total_time={total_time * 1e3:.2f}ms "
+                f"input_toks={input_token_count}}}")
+    stop_reason_str = StopReason.Name(stop_reason)
+
+    if stop_reason == StopReason.ERROR:
+        level = logging.ERROR
+    elif stop_reason in {StopReason.CANCELLED, StopReason.TOKEN_LIMIT}:
+        level = logging.WARN
+    else:
+        level = logging.INFO
+    logger.log(level,
+               f"{span_str}: {kind_log} generated "
+               f"{generated_token_count} tokens before "
+               f"{stop_reason_str}, output {output_len} chars: "
+               f"{short_output}")
+
+
+def _truncate(text: str, len_: int) -> bytes:
+    """Truncates a string and escapes control characters, for logging"""
+    text = f"{text:.{len_}}..." if len(text) > len_ else text
+    return text.encode("unicode_escape")
+
+
+def _safe_div(a: float, b: float, *, default: float = 0.0) -> float:
+    """Simple safe division with a default answer for divide-by-zero.
+    Used for logging where we don't mind incorrect answers.
+    """
+    try:
+        return a / b
+    except ZeroDivisionError:
+        return default

--- a/vllm/tgis_utils/logs.py
+++ b/vllm/tgis_utils/logs.py
@@ -16,7 +16,7 @@ def log_response(inputs: List[str], params: Parameters, prefix_id: str,
     tokenization_time = times.engine_start - times.request_start
     llm_engine_time = times.end - times.engine_start
     time_per_token = _safe_div(llm_engine_time, response.generated_token_count)
-    total_time = times.request_start - times.end
+    total_time = times.end - times.request_start
     output_len = len(response.text)
     short_output = _truncate(response.text, 32)
     short_input = [_truncate(input_, 32) for input_ in inputs]

--- a/vllm/tgis_utils/logs.py
+++ b/vllm/tgis_utils/logs.py
@@ -4,28 +4,21 @@ from typing import List
 
 from google.protobuf import text_format
 
-from vllm.entrypoints.grpc.pb.generation_pb2 import StopReason, Parameters
+from vllm.entrypoints.grpc.pb.generation_pb2 import (GenerationResponse,
+                                                     Parameters, StopReason)
 
 
-def log_response(inputs: List[str],
-                 output: str,
-                 params: Parameters,
-                 prefix_id: str,
-                 input_token_count: int,
-                 generated_token_count: int,
-                 stop_reason: StopReason,
-                 times: 'Times',
-                 kind_log: str,
-                 method_str: str,
-                 logger: logging.Logger):
+def log_response(inputs: List[str], params: Parameters, prefix_id: str,
+                 response: GenerationResponse, times, kind_log: str,
+                 method_str: str, logger: logging.Logger):
     """Logs responses similar to how the TGIS server does"""
     # This contains both request validation and tokenization
     tokenization_time = times.engine_start - times.request_start
     llm_engine_time = times.end - times.engine_start
-    time_per_token = _safe_div(llm_engine_time, generated_token_count)
+    time_per_token = _safe_div(llm_engine_time, response.generated_token_count)
     total_time = times.request_start - times.end
-    output_len = len(output)
-    short_output = _truncate(output, 32)
+    output_len = len(response.text)
+    short_output = _truncate(response.text, 32)
     short_input = [_truncate(input_, 32) for input_ in inputs]
     input_chars = sum(len(input_) for input_ in inputs)
 
@@ -36,20 +29,22 @@ def log_response(inputs: List[str],
                 f"queue_and_inference_time={llm_engine_time * 1e3:.2f}ms "
                 f"time_per_token={time_per_token * 1e3:.2f}ms "
                 f"total_time={total_time * 1e3:.2f}ms "
-                f"input_toks={input_token_count}}}")
-    stop_reason_str = StopReason.Name(stop_reason)
+                f"input_toks={response.input_token_count}}}")
+    stop_reason_str = StopReason.Name(response.stop_reason)
 
-    if stop_reason == StopReason.ERROR:
+    if response.stop_reason == StopReason.ERROR:
         level = logging.ERROR
-    elif stop_reason in {StopReason.CANCELLED, StopReason.TOKEN_LIMIT}:
+    elif response.stop_reason in {
+            StopReason.CANCELLED, StopReason.TOKEN_LIMIT
+    }:
         level = logging.WARN
     else:
         level = logging.INFO
-    logger.log(level,
-               f"{span_str}: {kind_log} generated "
-               f"{generated_token_count} tokens before "
-               f"{stop_reason_str}, output {output_len} chars: "
-               f"{short_output}")
+    logger.log(
+        level, f"{span_str}: {kind_log} generated "
+        f"{response.generated_token_count} tokens before "
+        f"{stop_reason_str}, output {output_len} chars: "
+        f"{short_output}")
 
 
 def _truncate(text: str, len_: int) -> bytes:

--- a/vllm/tgis_utils/logs.py
+++ b/vllm/tgis_utils/logs.py
@@ -12,7 +12,7 @@ def log_response(inputs: List[str], params: Parameters, prefix_id: str,
                  response: GenerationResponse, times, kind_log: str,
                  method_str: str, logger: logging.Logger):
     """Logs responses similar to how the TGIS server does"""
-    # This contains both request validation and tokenization
+    # This time contains both request validation and tokenization
     tokenization_time = times.engine_start - times.request_start
     llm_engine_time = times.end - times.engine_start
     time_per_token = _safe_div(llm_engine_time, response.generated_token_count)
@@ -48,14 +48,13 @@ def log_response(inputs: List[str], params: Parameters, prefix_id: str,
 
 
 def _truncate(text: str, len_: int) -> bytes:
-    """Truncates a string and escapes control characters, for logging"""
+    """Truncates a string and escapes control characters"""
     text = f"{text:.{len_}}..." if len(text) > len_ else text
     return text.encode("unicode_escape")
 
 
 def _safe_div(a: float, b: float, *, default: float = 0.0) -> float:
     """Simple safe division with a default answer for divide-by-zero.
-    Used for logging where we don't mind incorrect answers.
     """
     try:
         return a / b


### PR DESCRIPTION
This PR updates our grpc_server to add TGIS-style logs similar to https://github.com/IBM/text-generation-inference/blob/main/router/src/grpc_server.rs#L504-L512

This also disables the vllm per-request logging so that we don't double-log each request

The timing info collected here is pretty rough, it doesn't plumb into the LLMEngine, it just times the generators to get the total time spent in the engine. We could do better, but this is a start.

Example logs:

```
INFO 04-09 21:51:01 logs.py:43] generate_stream{input=[b'This is the story of Obama ridin...'] prefix_id= input_chars=[70] params=sampling { } stopping { max_new_tokens: 200 min_new_tokens: 16 } response { } decoding { } tokenization_time=0.45ms queue_and_inference_time=1096.67ms time_per_token=5.48ms total_time=1097.12ms input_toks=16}: Streaming response generated 200 tokens before NOT_FINISHED, output 848 chars: b' California. The story is told i...'
INFO 04-09 21:51:08 logs.py:43] generate{input=[b'Lorem ipsum dolor sit amet, cons...', b'foooood man where is it'] prefix_id= input_chars=[469] params=sampling { } stopping { max_new_tokens: 20 min_new_tokens: 16 } response { } decoding { } tokenization_time=2.03ms queue_and_inference_time=122.23ms time_per_token=6.11ms total_time=124.26ms input_toks=124}: Sub-request 0 from batch of 2 generated 20 tokens before MAX_TOKENS, output 25 chars: b'?\\n\\n<!--\\n<!--\\n<!--\\n<!--\\n<!'
INFO 04-09 21:51:08 logs.py:43] generate{input=[b'Lorem ipsum dolor sit amet, cons...', b'foooood man where is it'] prefix_id= input_chars=[469] params=sampling { } stopping { max_new_tokens: 20 min_new_tokens: 16 } response { } decoding { } tokenization_time=2.07ms queue_and_inference_time=122.22ms time_per_token=6.11ms total_time=124.29ms input_toks=7}: Sub-request 1 from batch of 2 generated 20 tokens before MAX_TOKENS, output 70 chars: b"?\\nI don't know.\\nI don't know.\\nI ..."
```