### PR TITLE
TGIS metrics

### DIFF
--- a/vllm/entrypoints/grpc/grpc_server.py
+++ b/vllm/entrypoints/grpc/grpc_server.py
@@ -37,7 +37,8 @@ from vllm.sequence import Logprob
 from vllm.tgis_utils import logs
 from vllm.tgis_utils.logits_processors import (ExpDecayLengthPenaltyWarper,
                                                TypicalLogitsWarperWrapper)
-from vllm.tgis_utils.metrics import TGISStatLogger, ServiceMetrics, FailureReasonLabel
+from vllm.tgis_utils.metrics import (FailureReasonLabel, ServiceMetrics,
+                                     TGISStatLogger)
 from vllm.transformers_utils.tokenizer_group import BaseTokenizerGroup
 
 logger = init_logger(__name__)
@@ -118,7 +119,9 @@ class TextGenerationService(generation_pb2_grpc.GenerationServiceServicer):
 
         # Swap in the special TGIS stats logger
         vllm_stat_logger = self.engine.engine.stat_logger
-        tgis_stats_logger = TGISStatLogger(vllm_stat_logger=vllm_stat_logger, max_sequence_len=self.config.max_model_len)
+        tgis_stats_logger = TGISStatLogger(
+            vllm_stat_logger=vllm_stat_logger,
+            max_sequence_len=self.config.max_model_len)
         # 🌶️🌶️🌶️ sneaky sneak
         self.engine.engine.stat_logger = tgis_stats_logger
 

--- a/vllm/tgis_utils/logs.py
+++ b/vllm/tgis_utils/logs.py
@@ -4,19 +4,23 @@ from typing import List
 
 from google.protobuf import text_format
 
+from vllm import RequestOutput
 from vllm.entrypoints.grpc.pb.generation_pb2 import (GenerationResponse,
                                                      Parameters, StopReason)
 
 
 def log_response(inputs: List[str], params: Parameters, prefix_id: str,
-                 response: GenerationResponse, times, kind_log: str,
-                 method_str: str, logger: logging.Logger):
+                 response: GenerationResponse, engine_response: RequestOutput,
+                 start_time: float, kind_log: str, method_str: str,
+                 logger: logging.Logger):
     """Logs responses similar to how the TGIS server does"""
     # This time contains both request validation and tokenization
-    tokenization_time = times.engine_start - times.request_start
-    llm_engine_time = times.end - times.engine_start
-    time_per_token = _safe_div(llm_engine_time, response.generated_token_count)
-    total_time = times.end - times.request_start
+    tokenization_time = engine_response.metrics.arrival_time - start_time
+    inference_time = (engine_response.metrics.last_token_time -
+                      engine_response.metrics.first_scheduled_time)
+    queue_time = engine_response.metrics.time_in_queue
+    time_per_token = _safe_div(inference_time, response.generated_token_count)
+    total_time = engine_response.metrics.last_token_time - start_time
     output_len = len(response.text)
     short_output = _truncate(response.text, 32)
     short_input = [_truncate(input_, 32) for input_ in inputs]
@@ -26,7 +30,8 @@ def log_response(inputs: List[str], params: Parameters, prefix_id: str,
     span_str = (f"{method_str}{{input={short_input} prefix_id={prefix_id} "
                 f"input_chars=[{input_chars}] params={paramstr} "
                 f"tokenization_time={tokenization_time * 1e3:.2f}ms "
-                f"queue_and_inference_time={llm_engine_time * 1e3:.2f}ms "
+                f"queue_time={queue_time * 1e3:.2f}ms "
+                f"inference_time={inference_time * 1e3:.2f}ms "
                 f"time_per_token={time_per_token * 1e3:.2f}ms "
                 f"total_time={total_time * 1e3:.2f}ms "
                 f"input_toks={response.input_token_count}}}")

--- a/vllm/tgis_utils/metrics.py
+++ b/vllm/tgis_utils/metrics.py
@@ -1,0 +1,87 @@
+"""Implements the logging for all tgi_* metrics for compatibility
+ with TGIS opsviz"""
+from enum import StrEnum, auto
+
+from prometheus_client import Counter, Gauge, Histogram
+
+from vllm import RequestOutput
+from vllm.engine.metrics import StatLogger, Stats
+from vllm.entrypoints.grpc.pb.generation_pb2 import BatchedTokenizeRequest, BatchedTokenizeResponse, \
+    BatchedGenerationRequest
+
+_duration_buckets = [0.001, 0.002, 0.005, 0.01, 0.02, 0.05, 0.1, 0.2, 0.5, 1, 2, 5, 10, 20, 50]
+
+class FailureReasonLabel(StrEnum):
+    VALIDATION = auto()
+    CANCELLED = auto()
+    CONC_LIMIT = auto()
+
+
+class ServiceMetrics:
+
+    def __init__(self):
+        # Tokenization API metrics
+        self.tgi_tokenize_request_tokens = Histogram("tgi_tokenize_request_tokens", documentation="Histogram of tokenized tokens per tokenize request", buckets=[1 << x for x in range(6, 20)])
+        self.tgi_tokenize_request_input_count = Counter("tgi_tokenize_request_input_count", documentation="Count of tokenize request inputs (batch of n counts as n)")
+
+        # Generate API metrics
+        self.tgi_request_input_count = Counter("tgi_request_input_count", documentation="Count of generate request inputs (batch of n counts as n)")
+        # err = validation|cancelled|conc_limit
+        self.tgi_request_failure = Counter("tgi_request_failure", labelnames=["err"], documentation="Count of failed requests, segmented by error type")
+        # The queue duration info from the vllm engine is only known at response time
+        self.tgi_request_queue_duration = Histogram("tgi_request_queue_duration", documentation="Request time spent in queue (in seconds)", buckets=_duration_buckets)
+
+    def observe_tokenization_request(self, request: BatchedTokenizeRequest):
+        self.tgi_tokenize_request_input_count.inc(len(request.requests))
+
+    def observe_tokenization_response(self, response: BatchedTokenizeResponse):
+        for tokenize_response in response.responses:
+            self.tgi_tokenize_request_tokens.observe(tokenize_response.token_count)
+
+    def count_generate_request(self, num_requests: int = 1):
+        self.tgi_request_input_count.inc(num_requests)
+
+    def observe_queue_time(self, engine_output: RequestOutput):
+        self.tgi_request_queue_duration.observe(engine_output.metrics.time_in_queue)
+
+    def observe_request_failure(self, reason: FailureReasonLabel):
+        self.tgi_request_failure.labels({"err": reason}).inc(1)
+
+
+class TGISStatLogger:
+    """Instance wraps the vLLM StatLogger to report TGIS metric names for compatibility"""
+
+    def __init__(self, vllm_stat_logger: StatLogger, max_sequence_len: int):
+        self._vllm_stat_logger = vllm_stat_logger
+
+        self.tgi_queue_size = Gauge("tgi_queue_size", documentation="Current number of queued requests")
+        self.tgi_batch_current_size = Gauge("tgi_batch_current_size", documentation="Current batch size")
+        # method = prefill|next_token
+        self.tgi_batch_inference_duration = Histogram("tgi_batch_inference_duration", labelnames=["method"], documentation="Time taken for each forward-pass iteration (in seconds)", buckets=_duration_buckets)
+
+        sequence_len_buckets = [max_sequence_len / 64.0 * (x + 1) for x in range(64)]
+        self.tgi_request_input_length = Histogram("tgi_request_input_length", documentation="Request input length in tokens", buckets=sequence_len_buckets)
+        self.tgi_request_generated_tokens = Histogram("tgi_request_generated_tokens", documentation="Number of tokens generated for request", buckets=sequence_len_buckets)
+
+    def log(self, stats: Stats) -> None:
+        # First, log the vLLM stats
+        self._vllm_stat_logger.log(stats)
+
+        # Then log TGIS specific ones
+        self.tgi_queue_size.set(stats.num_waiting + stats.num_swapped)
+        self.tgi_batch_current_size.set(stats.num_running)
+
+        for ttft in stats.time_to_first_tokens:
+            self.tgi_batch_inference_duration.labels({"method": "prefill"}).observe(ttft)
+        for tpot in stats.time_per_output_tokens:
+            self.tgi_batch_inference_duration.labels({"method": "next_token"}).observe(tpot)
+
+        # "num_prompt_tokens_lst"
+        # These metrics depend on open PR: https://github.com/vllm-project/vllm/pull/2764
+        if hasattr(stats, "num_prompt_tokens_lst"):
+            for input_len in stats.num_prompt_tokens_lst:
+                self.tgi_request_input_length.observe(input_len)
+            for output_len in stats.num_generation_tokens_lst:
+                self.tgi_request_generated_tokens.observe(output_len)
+
+

--- a/vllm/tgis_utils/metrics.py
+++ b/vllm/tgis_utils/metrics.py
@@ -6,17 +6,21 @@ from prometheus_client import Counter, Gauge, Histogram
 
 from vllm import RequestOutput
 from vllm.engine.metrics import StatLogger, Stats
-from vllm.entrypoints.grpc.pb.generation_pb2 import BatchedTokenizeRequest, BatchedTokenizeResponse, \
-    BatchedGenerationRequest
+from vllm.entrypoints.grpc.pb.generation_pb2 import (BatchedTokenizeRequest,
+                                                     BatchedTokenizeResponse)
 
-_duration_buckets = [0.001, 0.002, 0.005, 0.01, 0.02, 0.05, 0.1, 0.2, 0.5, 1, 2, 5, 10, 20, 50]
+_duration_buckets = [
+    0.001, 0.002, 0.005, 0.01, 0.02, 0.05, 0.1, 0.2, 0.5, 1, 2, 5, 10, 20, 50
+]
+
 
 class FailureReasonLabel(StrEnum):
     VALIDATION = auto()  # request validation failed
     CANCELLED = auto()  # TODO: cancellation handling not implemented
     CONC_LIMIT = auto()  # TODO: is this applicable for vLLM?
     OOM = auto()  # gpu OOM error
-    GENERATE = auto()  # some error happened while running a text generation request
+    GENERATE = auto(
+    )  # some error happened while running a text generation request
     TIMEOUT = auto()  # grpc deadline exceeded
     UNKNOWN = auto()
 
@@ -25,48 +29,84 @@ class ServiceMetrics:
 
     def __init__(self):
         # Tokenization API metrics
-        self.tgi_tokenize_request_tokens = Histogram("tgi_tokenize_request_tokens", documentation="Histogram of tokenized tokens per tokenize request", buckets=[1 << x for x in range(6, 20)])
-        self.tgi_tokenize_request_input_count = Counter("tgi_tokenize_request_input_count", documentation="Count of tokenize request inputs (batch of n counts as n)")
+        self.tgi_tokenize_request_tokens = Histogram(
+            "tgi_tokenize_request_tokens",
+            documentation="Histogram of tokenized tokens per tokenize request",
+            buckets=[1 << x for x in range(6, 20)])
+        self.tgi_tokenize_request_input_count = Counter(
+            "tgi_tokenize_request_input_count",
+            documentation=
+            "Count of tokenize request inputs (batch of n counts as n)")
 
         # Generate API metrics
-        self.tgi_request_input_count = Counter("tgi_request_input_count", documentation="Count of generate request inputs (batch of n counts as n)")
+        self.tgi_request_input_count = Counter(
+            "tgi_request_input_count",
+            documentation=
+            "Count of generate request inputs (batch of n counts as n)")
         # err = validation|cancelled|conc_limit
-        self.tgi_request_failure = Counter("tgi_request_failure", labelnames=["err"], documentation="Count of failed requests, segmented by error type")
-        # The queue duration info from the vllm engine is only known at response time
-        self.tgi_request_queue_duration = Histogram("tgi_request_queue_duration", documentation="Request time spent in queue (in seconds)", buckets=_duration_buckets)
+        self.tgi_request_failure = Counter(
+            "tgi_request_failure",
+            labelnames=["err"],
+            documentation="Count of failed requests, segmented by error type")
+        # The queue duration info from the vllm engine is only known at
+        # response time
+        self.tgi_request_queue_duration = Histogram(
+            "tgi_request_queue_duration",
+            documentation="Request time spent in queue (in seconds)",
+            buckets=_duration_buckets)
 
     def observe_tokenization_request(self, request: BatchedTokenizeRequest):
         self.tgi_tokenize_request_input_count.inc(len(request.requests))
 
     def observe_tokenization_response(self, response: BatchedTokenizeResponse):
         for tokenize_response in response.responses:
-            self.tgi_tokenize_request_tokens.observe(tokenize_response.token_count)
+            self.tgi_tokenize_request_tokens.observe(
+                tokenize_response.token_count)
 
     def count_generate_request(self, num_requests: int = 1):
         self.tgi_request_input_count.inc(num_requests)
 
     def observe_queue_time(self, engine_output: RequestOutput):
-        self.tgi_request_queue_duration.observe(engine_output.metrics.time_in_queue)
+        self.tgi_request_queue_duration.observe(
+            engine_output.metrics.time_in_queue)
 
     def count_request_failure(self, reason: FailureReasonLabel):
         self.tgi_request_failure.labels({"err": reason}).inc(1)
 
 
 class TGISStatLogger(StatLogger):
-    """Instance wraps the vLLM StatLogger to report TGIS metric names for compatibility"""
+    """Instance wraps the vLLM StatLogger to report TGIS metric names
+     for compatibility"""
 
     def __init__(self, vllm_stat_logger: StatLogger, max_sequence_len: int):
-        # Not calling super-init because we're wrapping and delegating to vllm_stat_logger
+        # Not calling super-init because we're wrapping and delegating to
+        # vllm_stat_logger
         self._vllm_stat_logger = vllm_stat_logger
 
-        self.tgi_queue_size = Gauge("tgi_queue_size", documentation="Current number of queued requests")
-        self.tgi_batch_current_size = Gauge("tgi_batch_current_size", documentation="Current batch size")
+        self.tgi_queue_size = Gauge(
+            "tgi_queue_size",
+            documentation="Current number of queued requests")
+        self.tgi_batch_current_size = Gauge("tgi_batch_current_size",
+                                            documentation="Current batch size")
         # method = prefill|next_token
-        self.tgi_batch_inference_duration = Histogram("tgi_batch_inference_duration", labelnames=["method"], documentation="Time taken for each forward-pass iteration (in seconds)", buckets=_duration_buckets)
+        self.tgi_batch_inference_duration = Histogram(
+            "tgi_batch_inference_duration",
+            labelnames=["method"],
+            documentation=
+            "Time taken for each forward-pass iteration (in seconds)",
+            buckets=_duration_buckets)
 
-        sequence_len_buckets = [max_sequence_len / 64.0 * (x + 1) for x in range(64)]
-        self.tgi_request_input_length = Histogram("tgi_request_input_length", documentation="Request input length in tokens", buckets=sequence_len_buckets)
-        self.tgi_request_generated_tokens = Histogram("tgi_request_generated_tokens", documentation="Number of tokens generated for request", buckets=sequence_len_buckets)
+        sequence_len_buckets = [
+            max_sequence_len / 64.0 * (x + 1) for x in range(64)
+        ]
+        self.tgi_request_input_length = Histogram(
+            "tgi_request_input_length",
+            documentation="Request input length in tokens",
+            buckets=sequence_len_buckets)
+        self.tgi_request_generated_tokens = Histogram(
+            "tgi_request_generated_tokens",
+            documentation="Number of tokens generated for request",
+            buckets=sequence_len_buckets)
 
     def info(self, type: str, obj: object) -> None:
         self._vllm_stat_logger.info(type, object)
@@ -80,9 +120,13 @@ class TGISStatLogger(StatLogger):
         self.tgi_batch_current_size.set(stats.num_running)
 
         for ttft in stats.time_to_first_tokens:
-            self.tgi_batch_inference_duration.labels({"method": "prefill"}).observe(ttft)
+            self.tgi_batch_inference_duration.labels({
+                "method": "prefill"
+            }).observe(ttft)
         for tpot in stats.time_per_output_tokens:
-            self.tgi_batch_inference_duration.labels({"method": "next_token"}).observe(tpot)
+            self.tgi_batch_inference_duration.labels({
+                "method": "next_token"
+            }).observe(tpot)
 
         # "num_prompt_tokens_lst"
         # These metrics depend on open PR: https://github.com/vllm-project/vllm/pull/2764
@@ -91,5 +135,3 @@ class TGISStatLogger(StatLogger):
                 self.tgi_request_input_length.observe(input_len)
             for output_len in stats.num_generation_tokens_lst:
                 self.tgi_request_generated_tokens.observe(output_len)
-
-

--- a/vllm/tgis_utils/metrics.py
+++ b/vllm/tgis_utils/metrics.py
@@ -128,7 +128,6 @@ class TGISStatLogger(StatLogger):
                 "method": "next_token"
             }).observe(tpot)
 
-        # "num_prompt_tokens_lst"
         # These metrics depend on open PR: https://github.com/vllm-project/vllm/pull/2764
         if hasattr(stats, "num_prompt_tokens_lst"):
             for input_len in stats.num_prompt_tokens_lst:


### PR DESCRIPTION
This PR implements a subset of the metrics from the TGIS image. I tried to make sure that everything from our current ops dashboard is supported. These are:

- tgi_tokenize_request_tokens 
- tgi_tokenize_request_input_count 
- tgi_request_input_count 
- tgi_request_failure 
- tgi_request_queue_duration 
- tgi_queue_size 
- tgi_batch_current_size 
- tgi_batch_inference_duration 
- tgi_request_input_length 
- tgi_request_generated_tokens

I colocated all the tgis metrics code in `tgis_utils/metrics.py` to make it easy to find and change. The metrics are reported either
- Directly by our code in `grpc_server.py` for data that's easily available at the grpc server level and not currently covered by the vllm StatLogger, or
- By a TGISStatLogger that wraps the vllm engine's StatLogger and is injected into the engine

The token length metrics depend on the open PR here: https://github.com/vllm-project/vllm/pull/2764. (But the rest of the metrics will function without those changes)
They could have been implemented right in the grpc server, but I wanted to keep this metrics reporting aligned with those upcoming changes.
