### PR TITLE
:sparkles: log all errored requests

### DIFF
--- a/vllm/entrypoints/grpc/grpc_server.py
+++ b/vllm/entrypoints/grpc/grpc_server.py
@@ -52,6 +52,11 @@ async def _handle_exception(e: Exception, func, *args, **kwargs):
     # We don't log AbortErrors since these correspond to gRPC errors
     # intentionally raised during handling of requests.
     if not isinstance(e, AbortError):
+        # try to replicate TGIS logs for when errors occur
+        if "generate" in func.__name__.lower():
+            request = kwargs.get("request", None) or args[-2]
+            logs.log_error(request=request, exception=e, logger=logger)
+
         if type(e).__name__ == "torch.cuda.OutOfMemoryError":  #TODO check
             context = kwargs.get("context", None) or args[-1]
             logger.exception("%s caused GPU OOM error", func.__name__)
@@ -172,14 +177,9 @@ class TextGenerationService(generation_pb2_grpc.GenerationServiceServicer):
             response = self._convert_input_details(res, resp_options,
                                                    sampling_params,
                                                    response)
-            if request_count == 1:
-                kind_log = "Request"
-            else:
-                kind_log = f"Sub-request {i} from batch of {request_count}"
-
-            self._log_unary_response(request=request, response=response,
-                                     start_time=start_time, engine_response=res,
-                                     kind_log=kind_log)
+            logs.log_response(request=request, response=response,
+                              start_time=start_time, engine_metrics=res.metrics,
+                              sub_request_num=i, logger=logger)
             responses[i] = response
 
         return BatchedGenerationResponse(responses=responses)
@@ -253,9 +253,11 @@ class TextGenerationService(generation_pb2_grpc.GenerationServiceServicer):
             return
         first_response.text = full_output
         first_response.generated_token_count = last_token_count
-        self._log_streaming_response(request=request, response=first_response,
-                                     start_time=start_time,
-                                     engine_response=last_engine_response)
+        logs.log_response(request=request, response=first_response,
+                          start_time=start_time,
+                          engine_metrics=last_engine_response.metrics
+                          if last_engine_response else None,
+                          logger=logger)
 
     def _convert_input_details(
             self, result: RequestOutput, resp_options: ResponseOptions,
@@ -536,30 +538,6 @@ class TextGenerationService(generation_pb2_grpc.GenerationServiceServicer):
             max_is_token_limit = True
 
         return input_ids, max_is_token_limit
-
-    @staticmethod
-    def _log_unary_response(request: BatchedGenerationRequest,
-                            response: GenerationResponse,
-                            engine_response: RequestOutput,
-                            start_time: float, kind_log: str):
-        logs.log_response(inputs=[r.text for r in request.requests],
-                          response=response, params=request.params,
-                          prefix_id=request.prefix_id,
-                          engine_response=engine_response,
-                          start_time=start_time, kind_log=kind_log,
-                          method_str="generate", logger=logger)
-
-    @staticmethod
-    def _log_streaming_response(request: SingleGenerationRequest,
-                                response: GenerationResponse,
-                                engine_response: RequestOutput,
-                                start_time: float):
-        logs.log_response(inputs=[request.request.text], response=response,
-                          params=request.params, prefix_id=request.prefix_id,
-                          engine_response=engine_response,
-                          start_time=start_time, kind_log="Streaming response",
-                          method_str="generate_stream", logger=logger)
-
 
     @log_rpc_handler_errors
     async def Tokenize(self, request: BatchedTokenizeRequest,

--- a/vllm/entrypoints/grpc/grpc_server.py
+++ b/vllm/entrypoints/grpc/grpc_server.py
@@ -49,21 +49,33 @@ def with_default(value: Any, default: Any) -> Any:
 
 
 async def _handle_exception(e: Exception, func, *args, **kwargs):
-    # We don't log AbortErrors since these correspond to gRPC errors
-    # intentionally raised during handling of requests.
-    if not isinstance(e, AbortError):
-        # try to replicate TGIS logs for when errors occur
-        if "generate" in func.__name__.lower():
-            request = kwargs.get("request", None) or args[-2]
-            logs.log_error(request=request, exception=e, logger=logger)
+    context = kwargs.get("context", None) or args[-1]
+    is_generate_fn = "generate" in func.__name__.lower()
 
+    # First just try to replicate the TGIS-style log messages
+    # for generate_* rpcs
+    if is_generate_fn:
+        if isinstance(e, AbortError):
+            # For things that we've already aborted, the relevant error
+            # string is already in the grpc context.
+            error_message = context.details()
+        else:
+            error_message = str(e)
+        request = kwargs.get("request", None) or args[-2]
+        logs.log_error(request=request,
+                       exception_str=error_message,
+                       logger=logger)
+
+    # AbortErrors likely correspond to things we've already explicitly handled,
+    # So we only add special handling for other types of errors
+    if not isinstance(e, AbortError):
         if type(e).__name__ == "torch.cuda.OutOfMemoryError":  #TODO check
             context = kwargs.get("context", None) or args[-1]
             logger.exception("%s caused GPU OOM error", func.__name__)
             service_metrics.count_request_failure(FailureReasonLabel.OOM)
             await context.abort(StatusCode.RESOURCE_EXHAUSTED, str(e))
         else:
-            if "generate" in func.__name__.lower():
+            if is_generate_fn:
                 service_metrics.count_request_failure(FailureReasonLabel.GENERATE)
             else:
                 service_metrics.count_request_failure(FailureReasonLabel.UNKNOWN)

--- a/vllm/tgis_utils/logs.py
+++ b/vllm/tgis_utils/logs.py
@@ -51,9 +51,11 @@ def log_response(
 
 
 def log_error(request: Union[BatchedGenerationRequest,
-                             SingleGenerationRequest], exception: Exception,
+                             SingleGenerationRequest], exception_str: str,
               logger: logging.Logger):
     """Logs errors similar to how the TGIS server does"""
+    # NB: We don't actually log the `Exception` here to match the TGIS behavior
+    # of just logging the simple string representation of the error
     params = request.params
     paramstr = text_format.MessageToString(params, as_one_line=True)
     prefix_id = request.prefix_id
@@ -69,11 +71,9 @@ def log_error(request: Union[BatchedGenerationRequest,
     input_chars = sum(len(input_) for input_ in inputs)
 
     span_str = (f"{method_str}{{input={short_input} prefix_id={prefix_id} "
-                f"input_chars=[{input_chars}] params={paramstr} ")
+                f"input_chars=[{input_chars}] params={paramstr}")
 
-    # Using %s to format the exception to only print the exception's message
-    # like TGIS does. (This is intentionally not using exc_info=True)
-    logger.error("%s: %s", span_str, exception)
+    logger.error("%s: %s", span_str, exception_str)
 
 
 def _log_response(inputs: List[str], params: Parameters, prefix_id: str,

--- a/vllm/tgis_utils/logs.py
+++ b/vllm/tgis_utils/logs.py
@@ -1,26 +1,99 @@
 """Some methods for producing logs similar to TGIS"""
 import logging
-from typing import List
+from typing import List, Optional, Union
 
 from google.protobuf import text_format
 
-from vllm import RequestOutput
-from vllm.entrypoints.grpc.pb.generation_pb2 import (GenerationResponse,
-                                                     Parameters, StopReason)
+from vllm.entrypoints.grpc.pb.generation_pb2 import (BatchedGenerationRequest,
+                                                     GenerationResponse,
+                                                     Parameters,
+                                                     SingleGenerationRequest,
+                                                     StopReason)
+from vllm.sequence import RequestMetrics
 
 
-def log_response(inputs: List[str], params: Parameters, prefix_id: str,
-                 response: GenerationResponse, engine_response: RequestOutput,
-                 start_time: float, kind_log: str, method_str: str,
-                 logger: logging.Logger):
+def log_response(
+    request: Union[BatchedGenerationRequest, SingleGenerationRequest],
+    response: GenerationResponse,
+    engine_metrics: Optional[RequestMetrics],
+    start_time: float,
+    logger: logging.Logger,
+    sub_request_num: int = 0,
+):
+    if isinstance(request, BatchedGenerationRequest):
+        # unary case
+        request_count = len(request.requests)
+        if request_count == 1:
+            kind_log = "Request"
+        else:
+            kind_log = (f"Sub-request {sub_request_num} from batch of "
+                        f"{request_count}")
+        _log_response(inputs=[r.text for r in request.requests],
+                      response=response,
+                      params=request.params,
+                      prefix_id=request.prefix_id,
+                      engine_metrics=engine_metrics,
+                      start_time=start_time,
+                      kind_log=kind_log,
+                      method_str="generate",
+                      logger=logger)
+    else:
+        # streaming case
+        _log_response(inputs=[request.request.text],
+                      response=response,
+                      params=request.params,
+                      prefix_id=request.prefix_id,
+                      engine_metrics=engine_metrics,
+                      start_time=start_time,
+                      kind_log="Streaming response",
+                      method_str="generate_stream",
+                      logger=logger)
+
+
+def log_error(request: Union[BatchedGenerationRequest,
+                             SingleGenerationRequest], exception: Exception,
+              logger: logging.Logger):
+    """Logs errors similar to how the TGIS server does"""
+    params = request.params
+    paramstr = text_format.MessageToString(params, as_one_line=True)
+    prefix_id = request.prefix_id
+
+    if isinstance(request, BatchedGenerationRequest):
+        method_str = "generate"
+        inputs = [r.text for r in request.requests]
+    else:
+        method_str = "generate_stream"
+        inputs = [request.request.text]
+
+    short_input = [_truncate(input_, 32) for input_ in inputs]
+    input_chars = sum(len(input_) for input_ in inputs)
+
+    span_str = (f"{method_str}{{input={short_input} prefix_id={prefix_id} "
+                f"input_chars=[{input_chars}] params={paramstr} ")
+
+    # Using %s to format the exception to only print the exception's message
+    # like TGIS does. (This is intentionally not using exc_info=True)
+    logger.error("%s: %s", span_str, exception)
+
+
+def _log_response(inputs: List[str], params: Parameters, prefix_id: str,
+                  response: GenerationResponse,
+                  engine_metrics: Optional[RequestMetrics], start_time: float,
+                  kind_log: str, method_str: str, logger: logging.Logger):
     """Logs responses similar to how the TGIS server does"""
     # This time contains both request validation and tokenization
-    tokenization_time = engine_response.metrics.arrival_time - start_time
-    inference_time = (engine_response.metrics.last_token_time -
-                      engine_response.metrics.first_scheduled_time)
-    queue_time = engine_response.metrics.time_in_queue
-    time_per_token = _safe_div(inference_time, response.generated_token_count)
-    total_time = engine_response.metrics.last_token_time - start_time
+    if engine_metrics is not None:
+        tokenization_time = engine_metrics.arrival_time - start_time
+        inference_time = (engine_metrics.last_token_time -
+                          engine_metrics.first_scheduled_time)
+        queue_time = engine_metrics.time_in_queue
+        time_per_token = _safe_div(inference_time,
+                                   response.generated_token_count)
+        total_time = engine_metrics.last_token_time - start_time
+    else:
+        logger.warning("No engine metrics for request, cannot log timing info")
+        tokenization_time = inference_time = queue_time = time_per_token =\
+            total_time = 0
     output_len = len(response.text)
     short_output = _truncate(response.text, 32)
     short_input = [_truncate(input_, 32) for input_ in inputs]


### PR DESCRIPTION
Drafting some changes to log all errors during validation or generation for a request like TGIS does. The goal is to get something like this:

```
2024-05-17T19:24:20.591834Z ERROR generate{input=["Hallo, wie heißt du? ..."] prefix_id=None correlation_id="<none>" input_bytes=[22] params=Some(Parameters { method: Sample, sampling: Some(SamplingParameters { temperature: 0.0, top_k: 3, top_p: 0.0, typical_p: 0.0, seed: None }), stopping: Some(StoppingCriteria { max_new_tokens: 20, min_new_tokens: 16, time_limit_millis: 0, stop_sequences: ["Peter ", "Timothy ", "joseph", "Corinthians"], include_stop_sequence: None }), response: Some(ResponseOptions { input_text: false, generated_tokens: false, input_tokens: false, token_logprobs: false, token_ranks: false, top_n_tokens: 0 }), decoding: Some(DecodingParameters { repetition_penalty: 2.0, length_penalty: Some(LengthPenalty { start_index: 0, decay_factor: 25.0 }) }), truncate_input_tokens: 0 })}: text_generation_router::grpc_server: src/grpc_server.rs:429: length_penalty must be >= 1.0 and <= 10.0
```

though probably without the file name/line number stuff (`text_generation_router::grpc_server: src/grpc_server.rs:429` in the example above) 