### PR TITLE
Add tokenization and truncation funcionality to Tokenize() function.

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -27,7 +27,7 @@ einops # required for MPT
 httpx
 peft
 requests
-ray
+#ray
 sentence-transformers # required for embedding
 
 # Benchmarking

--- a/tests/entrypoints/Makefile
+++ b/tests/entrypoints/Makefile
@@ -1,0 +1,15 @@
+gen-client:
+	# Compile protos
+	pip install grpcio-tools==1.60.0 mypy-protobuf==3.5.0 'types-protobuf>=3.20.4' --no-cache-dir
+	mkdir pb || true
+	python -m grpc_tools.protoc -I../../proto --python_out=pb \
+		--grpc_python_out=pb --mypy_out=pb ../../proto/generation.proto
+	find pb/ -type f -name "*.py" -print0 -exec sed -i -e 's/^\(import.*pb2\)/from . \1/g' {} \;
+	touch pb/__init__.py
+
+install: gen-client
+	pip install pip --upgrade
+	pip install -e . --no-cache-dir
+
+test:
+	pytest -sv test_server_tokenize_truncate.py

--- a/tests/entrypoints/test_server_tokenize_truncate.py
+++ b/tests/entrypoints/test_server_tokenize_truncate.py
@@ -1,0 +1,191 @@
+# imports for guided decoding tests
+import pytest
+# using Ray for overall ease of process management, parallel requests,
+# and debugging.
+import ray
+import grpc
+# to install pb, run Makefile to compile grpc protobuf
+from .pb import generation_pb2_grpc as gpb2, generation_pb2 as pb2
+from vllm.transformers_utils.tokenizer import get_tokenizer
+
+from ..utils import ServerRunner
+
+# Config. vars for gRPC
+SERVER = 'localhost'
+PORT = 8033
+
+# The tokenizer was tested using the following model:
+MODEL_NAME = "facebook/opt-125m"
+
+@pytest.fixture(scope="module")
+def server():
+    ray.init()
+    server_runner = ServerRunner.remote([
+        "--model",
+        MODEL_NAME,
+        # use half precision for speed and memory savings in CI environment
+        "--dtype",
+        "bfloat16"
+    ])
+    ray.get(server_runner.ready.remote())
+    yield server_runner
+    ray.shutdown()
+
+# Fixture to create a gRPC stub for the GenerationService
+@pytest.fixture(scope="module")
+def grpc_stub():
+    channel = grpc.insecure_channel(f"{SERVER}:{PORT}")
+    stub = gpb2.GenerationServiceStub(channel)
+    yield stub
+    channel.close()
+
+# Test cases
+@pytest.mark.parametrize("test_case", [
+    {
+        "name": "Tokenize with offsets",
+        "request": {
+            "text": "The very long story is written",
+            "return_offsets": True,
+        },
+        "response": {
+            "tokenCount": 7,
+            "offsets": [
+                {"start": 0, "end": 0},
+                {"start": 0, "end": 3},
+                {"start": 3, "end": 8},
+                {"start": 8, "end": 13},
+                {"start": 13, "end": 19},
+                {"start": 19, "end": 22},
+                {"start": 22, "end": 30},
+            ],
+        },
+    },
+    {
+        "name": "Tokenize with tokens and offsets",
+        "request": {
+            "text": "The very long story is written",
+            "return_tokens": True,
+            "return_offsets": True,
+        },
+        "response": {
+            "tokenCount": 7,
+            "tokens": [
+                "</s>",
+                "The",
+                "Ġvery",
+                "Ġlong",
+                "Ġstory",
+                "Ġis",
+                "Ġwritten"
+            ],
+            "offsets": [
+                {"start": 0, "end": 0},
+                {"start": 0, "end": 3},
+                {"start": 3, "end": 8},
+                {"start": 8, "end": 13},
+                {"start": 13, "end": 19},
+                {"start": 19, "end": 22},
+                {"start": 22, "end": 30},
+            ],
+        },
+    },
+    {
+        "name": "Tokenize with tokens and truncation",
+        "request": {
+            "text": "The very long story is written by a very long story",
+            "return_tokens": True,
+            "truncate_input_tokens": 10,
+        },
+        "response": {
+            "tokenCount": 10,
+            "tokens": [
+                "Ġvery",
+                "Ġlong",
+                "Ġstory",
+                "Ġis",
+                "Ġwritten",
+                "Ġby",
+                "Ġa",
+                "Ġvery",
+                "Ġlong",
+                "Ġstory",
+            ],
+        },
+    },
+    {
+        "name": "Tokenize, trunc and offset for a request with no text message",
+        "request": {
+            "text": "",
+            "return_offsets": True,
+            "return_tokens": True,
+            "truncate_input_tokens": 10,
+        },
+        "response": {
+            "tokenCount": 1,
+            "tokens": [
+                "</s>"
+            ],
+        },
+    },
+    {
+        "name": "A request without text ('') and parameters",
+        "request": {
+            "text" : ""
+        },
+        "response": {
+            "tokenCount": 1
+        },
+    },
+    {
+        "name": "A request without text (None) and parameters",
+        "request": {
+            "text" : None
+        },
+        "response": {
+            "tokenCount": 1
+        },
+    },
+])
+def test_tokenization(server, grpc_stub, test_case):
+    """Test tokenization with the given test case."""
+    text = test_case['request']['text']
+    truncate_input_tokens = test_case['request'].get('truncate_input_tokens',
+                                                    None)
+
+    # Construct the request
+    batch = pb2.BatchedTokenizeRequest(
+        model_id="unused",
+        requests=[pb2.TokenizeRequest(text=text)],
+        return_tokens=test_case['request'].get('return_tokens', False),
+        return_offsets=test_case['request'].get('return_offsets', False),
+        truncate_input_tokens=truncate_input_tokens
+    )
+
+    try:
+        responses = grpc_stub.Tokenize(batch).responses
+    except grpc.RpcError as e:
+        # Print debug message in case of connection failure
+        print(f"Failed to connect to the gRPC server: {e}")
+        pytest.fail(f"gRPC call failed with error: {e}")
+
+    # Verify the response
+    expected_response = test_case['response']
+    for resp in responses:
+        assert resp.token_count == expected_response['tokenCount'],\
+            "Token count mismatch"
+        if 'tokens' in expected_response:
+            assert resp.tokens == expected_response['tokens'],\
+                "Tokens mismatch"
+        if 'offsets' in expected_response:
+            expected_offsets = expected_response['offsets']
+            assert len(resp.offsets) == len(expected_offsets),\
+                "Offset length mismatch"
+            for resp_offset, exp_offset in zip(resp.offsets, expected_offsets):
+                assert resp_offset.start == exp_offset.get('start', None),\
+                    "Start offset mismatch"
+                assert resp_offset.end == exp_offset.get('end', None),\
+                    "End offset mismatch"
+    print("Test case passed: ", test_case["name"])
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/vllm/entrypoints/grpc/grpc_server.py
+++ b/vllm/entrypoints/grpc/grpc_server.py
@@ -578,7 +578,7 @@ class TextGenerationService(generation_pb2_grpc.GenerationServiceServicer):
         """
         # Log the incoming tokenization request for metrics
         service_metrics.observe_tokenization_request(request)
-        
+
         # Initialize an empty list to store individual tokenization responses
         responses: List[TokenizeResponse] = []
 
@@ -598,7 +598,7 @@ class TextGenerationService(generation_pb2_grpc.GenerationServiceServicer):
             if 1 <= request.truncate_input_tokens < token_count:
                 token_count = request.truncate_input_tokens
 
-            # Initialize Tokens fron ids
+            # Initialize Tokens from ids
             tokens = self.tokenizer.convert_ids_to_tokens(token_ids)
             offsets = None  # Initialize offsets to None
 
@@ -609,7 +609,7 @@ class TextGenerationService(generation_pb2_grpc.GenerationServiceServicer):
                     for start, end in batch_encoding.offset_mapping
                     if start is not None and end is not None
                 ]
-                # Truncate offset list if request.truncate_input_tokens  
+                # Truncate offset list if request.truncate_input_tokens
                 offsets=offsets[-token_count:]
 
             # Return a token list (Truncated if request.truncate_input_tokens)


### PR DESCRIPTION

Here, we use of `tokenizer.encode_plus()` directly because we don't want to modify `tokenizer_group.encode_async` and this function is part of upstream code/project. This implementation won't affect performance because  `tokenizer_group.encode_async` doesn't run `Tokenizer.encode` in a background thread. 
Should we add a unittest for this implementation? 