### PR TITLE
Add github workflow to run Spyre tests

### DIFF
--- a/.github/workflows/test-spyre.yml
+++ b/.github/workflows/test-spyre.yml
@@ -15,11 +15,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-    - name: Build docker images
+    - name: Build docker image
       run: docker build . -t vllm-spyre -f Dockerfile.spyre
-    - name: Run tests within docker image
+    - name: Run Spyre tests within docker container
       run: |
-        docker run -it --entrypoint /bin/bash vllm-spyre -c '''
+        docker run -i --rm --entrypoint /bin/bash vllm-spyre -c '''
           python3.12 -c "from transformers import pipeline; pipeline(\"text-generation\", model=\"JackFram/llama-160m\")" && \
           export VARIANT=$(ls /root/.cache/huggingface/hub/models--JackFram--llama-160m/snapshots/) && \
           mkdir -p /models && \

--- a/.github/workflows/test-spyre.yml
+++ b/.github/workflows/test-spyre.yml
@@ -25,5 +25,5 @@ jobs:
           mkdir -p /models && \
           ln -s /root/.cache/huggingface/hub/models--JackFram--llama-160m/snapshots/${VARIANT} /models/llama-194m && \
           pip install pytest sentence-transformers && \
-          python3.12 -m pytest tests/spyre
+          python3.12 -m pytest tests/spyre -v
         '''

--- a/.github/workflows/test-spyre.yml
+++ b/.github/workflows/test-spyre.yml
@@ -1,0 +1,28 @@
+name: test-sypre
+
+on:
+  # Trigger the workflow on push or pull request,
+  # but only for the main branch
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test-spyre:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+    - name: Build docker images
+      run: docker build . -t vllm-spyre -f Dockerfile.spyre
+    - name: Run tests within docker image
+      run: docker run -it --entrypoint /bin/bash vllm-spyre -c '''
+        python3.12 -c "from transformers import pipeline; pipeline(\"text-generation\", model=\"JackFram/llama-160m\")" && \
+        export VARIANT=$(ls /root/.cache/huggingface/hub/models--JackFram--llama-160m/snapshots/) && \
+        mkdir -p /models && \
+        ln -s /root/.cache/huggingface/hub/models--JackFram--llama-160m/snapshots/${VARIANT} /models/llama-194m && \
+        pip install pytest sentence-transformers && \
+        python3.12 -m pytest tests/spyre
+      '''

--- a/.github/workflows/test-spyre.yml
+++ b/.github/workflows/test-spyre.yml
@@ -18,11 +18,12 @@ jobs:
     - name: Build docker images
       run: docker build . -t vllm-spyre -f Dockerfile.spyre
     - name: Run tests within docker image
-      run: docker run -it --entrypoint /bin/bash vllm-spyre -c '''
-        python3.12 -c "from transformers import pipeline; pipeline(\"text-generation\", model=\"JackFram/llama-160m\")" && \
-        export VARIANT=$(ls /root/.cache/huggingface/hub/models--JackFram--llama-160m/snapshots/) && \
-        mkdir -p /models && \
-        ln -s /root/.cache/huggingface/hub/models--JackFram--llama-160m/snapshots/${VARIANT} /models/llama-194m && \
-        pip install pytest sentence-transformers && \
-        python3.12 -m pytest tests/spyre
-      '''
+      run: |
+        docker run -it --entrypoint /bin/bash vllm-spyre -c '''
+          python3.12 -c "from transformers import pipeline; pipeline(\"text-generation\", model=\"JackFram/llama-160m\")" && \
+          export VARIANT=$(ls /root/.cache/huggingface/hub/models--JackFram--llama-160m/snapshots/) && \
+          mkdir -p /models && \
+          ln -s /root/.cache/huggingface/hub/models--JackFram--llama-160m/snapshots/${VARIANT} /models/llama-194m && \
+          pip install pytest sentence-transformers && \
+          python3.12 -m pytest tests/spyre
+        '''

--- a/tests/spyre/spyre_util.py
+++ b/tests/spyre/spyre_util.py
@@ -134,7 +134,7 @@ def compare_results(model: str, prompts: List[str],
         print()
 
         assert DISABLE_ASSERTS or backend == 'sendnn_decoder' or\
-            hf_result['text'] == vllm_result['text']
+            hf_result['token_ids'] == vllm_result['token_ids']
 
         if len(hf_result['tokens']) > 0:
             print("   token id. token               logprob      "


### PR DESCRIPTION
This PR enables the Spyre tests to run as a Github action. 

I realized that the model we were using for the tests `llama-194m` is not available on HF hub, but if we want to run the tests externally we need to use some model that is available. I've replaced it with this one: https://huggingface.co/JackFram/llama-160m

Note I haven't actually changed the model name in the tests, I just "hacked" it for now using a soft link in the docker container. This is because there is some ongoing work to introduce environment variables to control the tests and I don't want to complicate things. 

For this model I see some quite weird behaviour where the tokens produced by vLLM and HF Transformers are identical but the decode text is slightly different (they are the same up to a leading space). I don't think this difference is related to Spyre so I've just changed the test to compare token ids instead. 

