### PR TITLE
Remove comments re: pytorch for outlines + compressed-tensors dependencies

### DIFF
--- a/requirements-common.txt
+++ b/requirements-common.txt
@@ -19,7 +19,7 @@ pillow  # Required for image processing
 prometheus-fastapi-instrumentator >= 7.0.0
 tiktoken >= 0.6.0  # Required for DBRX tokenizer
 lm-format-enforcer >= 0.10.9, < 0.11
-outlines == 0.1.11 # Requires pytorch
+outlines == 0.1.11
 lark == 1.2.2 
 xgrammar >= 0.1.6; platform_machine == "x86_64"
 typing_extensions >= 4.10
@@ -34,6 +34,6 @@ pyyaml
 six>=1.16.0; python_version > '3.11' # transitive dependency of pandas that needs to be the latest version for python 3.12
 setuptools>=74.1.1; python_version > '3.11' # Setuptools is used by triton, we need to ensure a modern version is installed for 3.12+ so that it does not try to import distutils, which was removed in 3.12
 einops # Required for Qwen2-VL.
-compressed-tensors == 0.8.1 # required for compressed-tensors, requires pytorch
+compressed-tensors == 0.8.1 # required for compressed-tensors
 depyf==0.18.0 # required for profiling and debugging with compilation config
 cloudpickle # allows pickling lambda functions in model_executor/models/registry.py


### PR DESCRIPTION
I already tried to fix this using https://github.com/IBM/vllm/pull/66 but upstream didn't like that change (the behaviour to filter out comments containing torch was intentional). After [some discussion](https://github.com/vllm-project/vllm/pull/12255), we agreed on a different solution implemented in this PR. Note that I reverted the changes from #66 by force pushing main. 

Note this has already been merged upstream by https://github.com/vllm-project/vllm/pull/12260 but I'm cherry-picking the fix here since it is blocking the CI builds. 
