### PR TITLE
improved code readability

### DIFF
--- a/vllm/worker/spyre_embedding_model_runner.py
+++ b/vllm/worker/spyre_embedding_model_runner.py
@@ -48,8 +48,7 @@ class SpyreEmbeddingModelRunner(SpyreModelRunner):
             softmax=False)
 
     def load_model(self, prompt_lens: Iterable[int],
-                   num_decode_tokens: Iterable[int],
-                   batch_sizes: Iterable[int]) -> None:
+                   num_decode_tokens: Iterable[int]) -> None:
         self.model = AutoModel.from_pretrained(self.model_config.model)
         self.model.eval()
         torch.set_grad_enabled(False)

--- a/vllm/worker/spyre_model_runner.py
+++ b/vllm/worker/spyre_model_runner.py
@@ -100,8 +100,7 @@ class SpyreModelRunner(ModelRunnerBase[ModelInputForSpyre]):
         self.model: nn.Module
 
     def load_model(self, prompt_lens: Iterable[int],
-                   num_decode_tokens: Iterable[int],
-                   batch_sizes: Iterable[int]) -> None:
+                   num_decode_tokens: Iterable[int]) -> None:
         max_pad_length = max(prompt_lens)
         max_decode_length = max(num_decode_tokens)
         self.model = get_spyre_model(self.model_config,

--- a/vllm/worker/spyre_worker.py
+++ b/vllm/worker/spyre_worker.py
@@ -59,7 +59,7 @@ class SpyreWorker(LoraNotSupportedWorkerBase, LocalOrDistributedWorkerBase):
                                                  self.is_driver_worker)
         self._env_initialized = False
 
-    def init_distributed_environment(self) -> None:
+    def init_distributed_spyre_environment(self) -> None:
         """Initialize the distributed environment."""
 
         torch._C._distributed_c10d._register_process_group(
@@ -91,7 +91,7 @@ class SpyreWorker(LoraNotSupportedWorkerBase, LocalOrDistributedWorkerBase):
             )
 
             if self.parallel_config.world_size > 1:
-                self.init_distributed_environment()
+                self.init_distributed_spyre_environment()
             elif envs.VLLM_SPYRE_DYNAMO_BACKEND in [
                     "sendnn", "sendnn_decoder"
             ]:

--- a/vllm/worker/spyre_worker.py
+++ b/vllm/worker/spyre_worker.py
@@ -59,7 +59,7 @@ class SpyreWorker(LoraNotSupportedWorkerBase, LocalOrDistributedWorkerBase):
                                                  self.is_driver_worker)
         self._env_initialized = False
 
-    def init_distributed_spyre_environment(self) -> None:
+    def init_distributed_environment(self) -> None:
         """Initialize the distributed environment."""
 
         torch._C._distributed_c10d._register_process_group(
@@ -91,7 +91,7 @@ class SpyreWorker(LoraNotSupportedWorkerBase, LocalOrDistributedWorkerBase):
             )
 
             if self.parallel_config.world_size > 1:
-                self.init_distributed_spyre_environment()
+                self.init_distributed_environment()
             elif envs.VLLM_SPYRE_DYNAMO_BACKEND in [
                     "sendnn", "sendnn_decoder"
             ]:

--- a/vllm/worker/spyre_worker.py
+++ b/vllm/worker/spyre_worker.py
@@ -126,13 +126,12 @@ class SpyreWorker(LoraNotSupportedWorkerBase, LocalOrDistributedWorkerBase):
         # printing env variables for debugging purposes
         load_model_start_t = time.time()
 
-        wup_prompt_lens, wup_new_tokens, wup_batch_sizes = zip(
-            *[(s["prompt_length"], s["new_tokens"], s["batch_size"])
+        wup_prompt_lens, wup_new_tokens = zip(
+            *[(s["prompt_length"], s["new_tokens"])
               for s in self.scheduler_config.spyre_warmup_shapes])
 
         self.model_runner.load_model(prompt_lens=wup_prompt_lens,
-                                     num_decode_tokens=wup_new_tokens,
-                                     batch_sizes=wup_batch_sizes)
+                                     num_decode_tokens=wup_new_tokens)
 
         load_model_end_t = time.time()
         load_model_total_t = load_model_end_t - load_model_start_t


### PR DESCRIPTION
this PR improves code readability by

- [commit 1](https://github.com/IBM/vllm/commit/0c9bec0b2650e3b23f12c30f0d2e92e27983f9e6): removing the batch size argument in the load_model function [here](https://github.com/IBM/vllm/blob/124f3a961d1a9ce2628c01fe56dfcc589a49c8dd/vllm/worker/spyre_worker.py#L135) since unused in `SpyreModelRunner` ([here](https://github.com/IBM/vllm/blob/124f3a961d1a9ce2628c01fe56dfcc589a49c8dd/vllm/worker/spyre_model_runner.py#L104)) as well as in `SpyreEmbeddingModelRunner` ([here](https://github.com/IBM/vllm/blob/124f3a961d1a9ce2628c01fe56dfcc589a49c8dd/vllm/worker/spyre_embedding_model_runner.py#L52)).
- -- _[commit 2](https://github.com/IBM/vllm/commit/beadbd59fc7703fabb74cfe3a50c3c7fb5060f49): function renaming to better distinguish between the imported function `init_distributed_environment` from `vllm.distributed` and our own function `self.init_distributed_environment`._ -- (**reverted since this seems to be a convention introduced in other worker classes**)

