### PR TITLE
Dpatel enable tests on spyre

### DIFF
--- a/tests/spyre/spyre_util.py
+++ b/tests/spyre/spyre_util.py
@@ -296,9 +296,6 @@ def get_spyre_backend_list(isEmbeddings=False):
     test_backend_list = []
     user_backend_list = os.environ.get("SPYRE_TEST_BACKEND_LIST", "eager")
 
-    # set default to sendnn if testing embeddings
-    if isEmbeddings:
-        user_backend_list = os.environ.get("SPYRE_TEST_BACKEND_LIST", "sendnn")
     for backend in user_backend_list.split(","):
         test_backend_list.append(backend.strip())
     return test_backend_list

--- a/tests/spyre/spyre_util.py
+++ b/tests/spyre/spyre_util.py
@@ -281,3 +281,43 @@ def compare_embedding_results(model: str, prompts: List[str],
                                    vllm_result["embeddings"])
 
         assert math.isclose(sim, 1.0, rel_tol=0.05)
+
+
+# get model directory path from env, if not set then default to "/models".
+def get_spyre_model_dir_path():
+    model_dir_path = os.environ.get("SPYRE_TEST_MODEL_DIR", "/models")
+    return model_dir_path
+
+
+# get model backend from env, if not set then default to "eager"
+# For multiple values:
+# export SPYRE_TEST_BACKEND_LIST="eager, inductor, sendnn_decoder"
+def get_spyre_backend_list(isEmbeddings=False):
+    test_backend_list = []
+    user_backend_list = os.environ.get("SPYRE_TEST_BACKEND_LIST", "eager")
+
+    # set default to sendnn if testing embeddings
+    if isEmbeddings:
+        user_backend_list = os.environ.get("SPYRE_TEST_BACKEND_LIST", "sendnn")
+    for backend in user_backend_list.split(","):
+        test_backend_list.append(backend.strip())
+    return test_backend_list
+
+
+# get model names from env, if not set then default to "llama-194m"
+# For multiple values:
+# export SPYRE_TEST_MODEL_LIST="llama-194m,all-roberta-large-v1"
+def get_spyre_model_list(isEmbeddings=False):
+    spyre_model_dir_path = get_spyre_model_dir_path()
+    test_model_list = []
+    user_test_model_list = os.environ.get("SPYRE_TEST_MODEL_LIST",
+                                          "llama-194m")
+
+    # set default to bert if testing embeddings
+    if isEmbeddings:
+        user_test_model_list = os.environ.get("SPYRE_TEST_MODEL_LIST",
+                                              "all-roberta-large-v1")
+
+    for model in user_test_model_list.split(","):
+        test_model_list.append(f"{spyre_model_dir_path}/{model.strip()}")
+    return test_model_list

--- a/tests/spyre/spyre_util.py
+++ b/tests/spyre/spyre_util.py
@@ -292,7 +292,7 @@ def get_spyre_model_dir_path():
 # get model backend from env, if not set then default to "eager"
 # For multiple values:
 # export SPYRE_TEST_BACKEND_LIST="eager, inductor, sendnn_decoder"
-def get_spyre_backend_list(isEmbeddings=False):
+def get_spyre_backend_list():
     test_backend_list = []
     user_backend_list = os.environ.get("SPYRE_TEST_BACKEND_LIST", "eager")
 

--- a/tests/spyre/test_spyre_basic.py
+++ b/tests/spyre/test_spyre_basic.py
@@ -10,9 +10,25 @@ from spyre_util import (compare_results, generate_hf_output,
                         generate_spyre_vllm_output)
 
 from vllm import SamplingParams
+import os
 
+# get model directory path from env, if not set then default to "/models". 
+model_dir_path = os.environ.get("SPYRE_TEST_MODEL_DIR", "/models")
+# get model backend from env, if not set then default to "eager" 
+# For multiple values, export SPYRE_TEST_MODEL_DIR="eager,inductor"
+backend_type = os.environ.get("SYPRE_TEST_BACKEND_TYPE", "eager")
+# get model names from env, if not set then default to "llama-194m" 
+# For multiple values, export SPYRE_TEST_MODEL_DIR="llama-194m,all-roberta-large-v1"
+user_test_model_list = os.environ.get("SPYRE_TEST_MODEL_LIST","llama-194m")
+test_model_list, test_backend_list = [],[]
 
-@pytest.mark.parametrize("model", ["/models/llama-194m"])
+for model in user_test_model_list.split(','):
+    test_model_list.append(f"{model_dir_path}/{model.strip()}")
+
+for backend in backend_type.split(','):
+    test_backend_list.append(backend.strip())
+
+@pytest.mark.parametrize("model", test_model_list)
 @pytest.mark.parametrize("prompts", [[
     "Provide a list of instructions for preparing"
     " chicken soup for a family of four.", "Hello",
@@ -20,9 +36,10 @@ from vllm import SamplingParams
 ]])
 @pytest.mark.parametrize("warmup_shape", [(64, 20, 4), (64, 20, 8),
                                           (128, 20, 4), (128, 20, 8)]
+# @pytest.mark.parametrize("warmup_shape", [(64, 20, 1), (128, 20, 1)]
                          )  # (prompt_length/new_tokens/batch_size)
 @pytest.mark.parametrize("backend",
-                         ["eager"])  #, "inductor", "sendnn_decoder"])
+                         test_backend_list)  #, "inductor", "sendnn_decoder"])
 def test_output(
     model: str,
     prompts: List[str],

--- a/tests/spyre/test_spyre_basic.py
+++ b/tests/spyre/test_spyre_basic.py
@@ -16,7 +16,7 @@ import os
 model_dir_path = os.environ.get("SPYRE_TEST_MODEL_DIR", "/models")
 # get model backend from env, if not set then default to "eager" 
 # For multiple values, export SPYRE_TEST_MODEL_DIR="eager,inductor"
-backend_type = os.environ.get("SYPRE_TEST_BACKEND_TYPE", "eager")
+backend_type = os.environ.get("SPYRE_TEST_BACKEND_TYPE", "eager")
 # get model names from env, if not set then default to "llama-194m" 
 # For multiple values, export SPYRE_TEST_MODEL_DIR="llama-194m,all-roberta-large-v1"
 user_test_model_list = os.environ.get("SPYRE_TEST_MODEL_LIST","llama-194m")

--- a/tests/spyre/test_spyre_basic.py
+++ b/tests/spyre/test_spyre_basic.py
@@ -7,38 +7,27 @@ from typing import List, Tuple
 
 import pytest
 from spyre_util import (compare_results, generate_hf_output,
-                        generate_spyre_vllm_output)
+                        generate_spyre_vllm_output, get_spyre_backend_list,
+                        get_spyre_model_list)
 
 from vllm import SamplingParams
-import os
 
-# get model directory path from env, if not set then default to "/models". 
-model_dir_path = os.environ.get("SPYRE_TEST_MODEL_DIR", "/models")
-# get model backend from env, if not set then default to "eager" 
-# For multiple values, export SPYRE_TEST_BACKEND_LIST="eager,inductor,sendnn_decoder"
-backend_list = os.environ.get("SPYRE_TEST_BACKEND_LIST", "eager")
-# get model names from env, if not set then default to "llama-194m" 
-# For multiple values, export SPYRE_TEST_MODEL_LIST="llama-194m,all-roberta-large-v1"
-user_test_model_list = os.environ.get("SPYRE_TEST_MODEL_LIST","llama-194m")
-test_model_list, test_backend_list = [],[]
 
-for model in user_test_model_list.split(','):
-    test_model_list.append(f"{model_dir_path}/{model.strip()}")
-
-for backend in backend_list.split(','):
-    test_backend_list.append(backend.strip())
-
-@pytest.mark.parametrize("model", test_model_list)
-@pytest.mark.parametrize("prompts", [[
-    "Provide a list of instructions for preparing"
-    " chicken soup for a family of four.", "Hello",
-    "What is the weather today like?", "Who are you?"
-]])
+@pytest.mark.parametrize("model", get_spyre_model_list())
+@pytest.mark.parametrize(
+    "prompts",
+    [[
+        "Provide a list of instructions for preparing"
+        " chicken soup for a family of four.",
+        "Hello",
+        "What is the weather today like?",
+        "Who are you?",
+    ]],
+)
 @pytest.mark.parametrize("warmup_shape", [(64, 20, 4), (64, 20, 8),
                                           (128, 20, 4), (128, 20, 8)]
                          )  # (prompt_length/new_tokens/batch_size)
-@pytest.mark.parametrize("backend",
-                         test_backend_list) 
+@pytest.mark.parametrize("backend", get_spyre_backend_list())
 def test_output(
     model: str,
     prompts: List[str],
@@ -64,7 +53,8 @@ def test_output(
         max_tokens=max_new_tokens,
         temperature=0,
         logprobs=0,  # return logprobs of generated tokens only
-        ignore_eos=True)
+        ignore_eos=True,
+    )
 
     vllm_results = generate_spyre_vllm_output(
         model=model,
@@ -74,16 +64,19 @@ def test_output(
         block_size=2048,
         sampling_params=vllm_sampling_params,
         tensor_parallel_size=1,
-        backend=backend)
+        backend=backend,
+    )
 
     hf_results = generate_hf_output(model=model,
                                     prompts=prompts,
                                     max_new_tokens=max_new_tokens)
 
-    compare_results(model=model,
-                    prompts=prompts,
-                    warmup_shapes=[warmup_shape],
-                    tensor_parallel_size=1,
-                    backend=backend,
-                    vllm_results=vllm_results,
-                    hf_results=hf_results)
+    compare_results(
+        model=model,
+        prompts=prompts,
+        warmup_shapes=[warmup_shape],
+        tensor_parallel_size=1,
+        backend=backend,
+        vllm_results=vllm_results,
+        hf_results=hf_results,
+    )

--- a/tests/spyre/test_spyre_basic.py
+++ b/tests/spyre/test_spyre_basic.py
@@ -15,17 +15,17 @@ import os
 # get model directory path from env, if not set then default to "/models". 
 model_dir_path = os.environ.get("SPYRE_TEST_MODEL_DIR", "/models")
 # get model backend from env, if not set then default to "eager" 
-# For multiple values, export SPYRE_TEST_MODEL_DIR="eager,inductor"
-backend_type = os.environ.get("SPYRE_TEST_BACKEND_TYPE", "eager")
+# For multiple values, export SPYRE_TEST_BACKEND_LIST="eager,inductor,sendnn_decoder"
+backend_list = os.environ.get("SPYRE_TEST_BACKEND_LIST", "eager")
 # get model names from env, if not set then default to "llama-194m" 
-# For multiple values, export SPYRE_TEST_MODEL_DIR="llama-194m,all-roberta-large-v1"
+# For multiple values, export SPYRE_TEST_MODEL_LIST="llama-194m,all-roberta-large-v1"
 user_test_model_list = os.environ.get("SPYRE_TEST_MODEL_LIST","llama-194m")
 test_model_list, test_backend_list = [],[]
 
 for model in user_test_model_list.split(','):
     test_model_list.append(f"{model_dir_path}/{model.strip()}")
 
-for backend in backend_type.split(','):
+for backend in backend_list.split(','):
     test_backend_list.append(backend.strip())
 
 @pytest.mark.parametrize("model", test_model_list)
@@ -36,10 +36,9 @@ for backend in backend_type.split(','):
 ]])
 @pytest.mark.parametrize("warmup_shape", [(64, 20, 4), (64, 20, 8),
                                           (128, 20, 4), (128, 20, 8)]
-# @pytest.mark.parametrize("warmup_shape", [(64, 20, 1), (128, 20, 1)]
                          )  # (prompt_length/new_tokens/batch_size)
 @pytest.mark.parametrize("backend",
-                         test_backend_list)  #, "inductor", "sendnn_decoder"])
+                         test_backend_list) 
 def test_output(
     model: str,
     prompts: List[str],

--- a/tests/spyre/test_spyre_embeddings.py
+++ b/tests/spyre/test_spyre_embeddings.py
@@ -13,7 +13,7 @@ import os
 model_dir_path = os.environ.get("SPYRE_TEST_MODEL_DIR", "/models")
 # get model backend from env, if not set then default to "eager" 
 # For multiple values, export SPYRE_TEST_MODEL_DIR="eager,inductor"
-backend_type = os.environ.get("SYPRE_TEST_BACKEND_TYPE", "eager")
+backend_type = os.environ.get("SPYRE_TEST_BACKEND_TYPE", "eager")
 # get model names from env, if not set then default to "llama-194m" 
 # For multiple values, export SPYRE_TEST_MODEL_DIR="llama-194m,all-roberta-large-v1"
 user_test_model_list = os.environ.get("SPYRE_TEST_EMBEDDING_MODEL_LIST","all-roberta-large-v1")

--- a/tests/spyre/test_spyre_embeddings.py
+++ b/tests/spyre/test_spyre_embeddings.py
@@ -26,7 +26,7 @@ from spyre_util import (compare_embedding_results, spyre_vllm_embeddings,
 @pytest.mark.parametrize("warmup_shape",
                          [(64, 4), (64, 8), (128, 4),
                           (128, 8)])  # (prompt_length/new_tokens/batch_size)
-@pytest.mark.parametrize("backend", get_spyre_backend_list(isEmbeddings=True))
+@pytest.mark.parametrize("backend", get_spyre_backend_list())
 def test_output(
     model: str,
     prompts: List[str],

--- a/tests/spyre/test_spyre_embeddings.py
+++ b/tests/spyre/test_spyre_embeddings.py
@@ -1,6 +1,6 @@
 """Verification of vLLM output by comparing with HF
 
-Run `python -m pytest tests/spyre/test_spyre_basic.py`.
+Run `python -m pytest tests/spyre/test_spyre_embeddings.py`.
 """
 
 from typing import List, Tuple

--- a/tests/spyre/test_spyre_embeddings.py
+++ b/tests/spyre/test_spyre_embeddings.py
@@ -12,17 +12,17 @@ import os
 # get model directory path from env, if not set then default to "/models". 
 model_dir_path = os.environ.get("SPYRE_TEST_MODEL_DIR", "/models")
 # get model backend from env, if not set then default to "eager" 
-# For multiple values, export SPYRE_TEST_MODEL_DIR="eager,inductor"
-backend_type = os.environ.get("SPYRE_TEST_BACKEND_TYPE", "eager")
-# get model names from env, if not set then default to "llama-194m" 
-# For multiple values, export SPYRE_TEST_MODEL_DIR="llama-194m,all-roberta-large-v1"
+# For multiple values, export SPYRE_TEST_BACKEND_LIST="eager,inductor,sendnn_decoder"
+backend_list = os.environ.get("SPYRE_TEST_BACKEND_LIST", "eager")
+# get model names from env, if not set then default to "all-roberta-large-v1" 
+# For multiple values, export SPYRE_TEST_MODEL_LIST="llama-194m,all-roberta-large-v1"
 user_test_model_list = os.environ.get("SPYRE_TEST_EMBEDDING_MODEL_LIST","all-roberta-large-v1")
 test_model_list, test_backend_list = [],[]
 
 for model in user_test_model_list.split(','):
     test_model_list.append(f"{model_dir_path}/{model.strip()}")
 
-for backend in backend_type.split(','):
+for backend in backend_list.split(','):
     test_backend_list.append(backend.strip())
 
 @pytest.mark.parametrize("model", test_model_list)
@@ -36,7 +36,7 @@ for backend in backend_type.split(','):
                          [(64, 4), (64, 8), (128, 4),
                           (128, 8)])  # (prompt_length/new_tokens/batch_size)
 @pytest.mark.parametrize("backend",
-                         test_backend_list)  #, "inductor", "sendnn_decoder"])
+                         test_backend_list)
 def test_output(
     model: str,
     prompts: List[str],

--- a/tests/spyre/test_spyre_max_new_tokens.py
+++ b/tests/spyre/test_spyre_max_new_tokens.py
@@ -6,8 +6,11 @@ Run `python -m pytest tests/spyre/test_spyre_max_new_tokens.py`.
 from typing import List, Tuple
 
 import pytest
-from spyre_util import (compare_results, generate_hf_output,
-                        generate_spyre_vllm_output)
+from spyre_util import (
+    compare_results,
+    generate_hf_output,
+    generate_spyre_vllm_output,
+)
 
 from vllm import SamplingParams
 
@@ -22,14 +25,19 @@ prompt2 = template.format("Provide a list of instructions for preparing "
 
 
 @pytest.mark.parametrize("model", ["/models/llama-194m"])
-@pytest.mark.parametrize("prompts", [[prompt1, prompt2, prompt2, prompt2],
-                                     [prompt2, prompt2, prompt2, prompt1],
-                                     [prompt2, prompt2, prompt2, prompt2]])
+@pytest.mark.parametrize(
+    "prompts",
+    [
+        [prompt1, prompt2, prompt2, prompt2],
+        [prompt2, prompt2, prompt2, prompt1],
+        [prompt2, prompt2, prompt2, prompt2],
+    ],
+)
 @pytest.mark.parametrize("stop_last", [True, False])
 @pytest.mark.parametrize("warmup_shape", [(64, 10, 4)]
                          )  # (prompt_length/new_tokens/batch_size)
 @pytest.mark.parametrize("backend",
-                         ["eager"])  #, "inductor", "sendnn_decoder"])
+                         ["eager"])  # , "inductor", "sendnn_decoder"])
 def test_output(
     model: str,
     prompts: List[str],
@@ -57,13 +65,15 @@ def test_output(
         max_tokens=max_new_tokens_warmup,
         temperature=0,
         logprobs=0,  # return logprobs of generated tokens only
-        ignore_eos=False)
+        ignore_eos=False,
+    )
 
     vllm_sampling_params_early_stop = SamplingParams(
         max_tokens=max_new_tokens_early_stop,
         temperature=0,
         logprobs=0,  # return logprobs of generated tokens only
-        ignore_eos=False)
+        ignore_eos=False,
+    )
 
     vllm_sampling_params = [vllm_sampling_params_normal] * 3
     hf_max_new_tokens = [max_new_tokens_warmup] * 3
@@ -87,16 +97,19 @@ def test_output(
         block_size=2048,
         sampling_params=vllm_sampling_params,
         tensor_parallel_size=1,
-        backend=backend)
+        backend=backend,
+    )
 
     hf_results = generate_hf_output(model=model,
                                     prompts=prompts,
                                     max_new_tokens=hf_max_new_tokens)
 
-    compare_results(model=model,
-                    prompts=prompts,
-                    warmup_shapes=[warmup_shape],
-                    tensor_parallel_size=1,
-                    backend=backend,
-                    vllm_results=vllm_results,
-                    hf_results=hf_results)
+    compare_results(
+        model=model,
+        prompts=prompts,
+        warmup_shapes=[warmup_shape],
+        tensor_parallel_size=1,
+        backend=backend,
+        vllm_results=vllm_results,
+        hf_results=hf_results,
+    )

--- a/tests/spyre/test_spyre_max_prompt_length.py
+++ b/tests/spyre/test_spyre_max_prompt_length.py
@@ -16,17 +16,17 @@ import os
 # get model directory path from env, if not set then default to "/models". 
 model_dir_path = os.environ.get("SPYRE_TEST_MODEL_DIR", "/models")
 # get model backend from env, if not set then default to "eager" 
-# For multiple values, export SPYRE_TEST_MODEL_DIR="eager,inductor"
-backend_type = os.environ.get("SPYRE_TEST_BACKEND_TYPE", "eager")
+# For multiple values, export SPYRE_TEST_BACKEND_LIST="eager,inductor,sendnn_decoder"
+backend_list = os.environ.get("SPYRE_TEST_BACKEND_LIST", "eager")
 # get model names from env, if not set then default to "llama-194m" 
-# For multiple values, export SPYRE_TEST_MODEL_DIR="llama-194m,all-roberta-large-v1"
+# For multiple values, export SPYRE_TEST_MODEL_LIST="llama-194m,all-roberta-large-v1"
 user_test_model_list = os.environ.get("SPYRE_TEST_MODEL_LIST","llama-194m")
 test_model_list, test_backend_list = [],[]
 
 for model in user_test_model_list.split(','):
     test_model_list.append(f"{model_dir_path}/{model.strip()}")
 
-for backend in backend_type.split(','):
+for backend in backend_list.split(','):
     test_backend_list.append(backend.strip())
 
 @pytest.mark.parametrize("model", test_model_list)
@@ -43,12 +43,9 @@ for backend in backend_type.split(','):
 ])
 @pytest.mark.parametrize("warmup_shapes",
                          [[(64, 20, 4)], [(64, 20, 4), (128, 20, 4)]]
-#                          )  # (prompt_length/new_tokens/batch_size)
-# @pytest.mark.parametrize("warmup_shapes",
-#                          [[(64, 20, 1)], [(128, 20, 1)]]
-                         )  # (prompt_length/new_tokens/batch_size)
+                        )  # (prompt_length/new_tokens/batch_size)
 @pytest.mark.parametrize("backend",
-                         test_backend_list)  #, "inductor", "sendnn_decoder"])
+                         test_backend_list)
 def test_output(
     model: str,
     prompts: List[str],

--- a/tests/spyre/test_spyre_max_prompt_length.py
+++ b/tests/spyre/test_spyre_max_prompt_length.py
@@ -17,7 +17,7 @@ import os
 model_dir_path = os.environ.get("SPYRE_TEST_MODEL_DIR", "/models")
 # get model backend from env, if not set then default to "eager" 
 # For multiple values, export SPYRE_TEST_MODEL_DIR="eager,inductor"
-backend_type = os.environ.get("SYPRE_TEST_BACKEND_TYPE", "eager")
+backend_type = os.environ.get("SPYRE_TEST_BACKEND_TYPE", "eager")
 # get model names from env, if not set then default to "llama-194m" 
 # For multiple values, export SPYRE_TEST_MODEL_DIR="llama-194m,all-roberta-large-v1"
 user_test_model_list = os.environ.get("SPYRE_TEST_MODEL_LIST","llama-194m")

--- a/tests/spyre/test_spyre_max_prompt_length.py
+++ b/tests/spyre/test_spyre_max_prompt_length.py
@@ -11,9 +11,25 @@ from spyre_util import (compare_results, generate_hf_output,
 from transformers import AutoTokenizer
 
 from vllm import SamplingParams
+import os
 
+# get model directory path from env, if not set then default to "/models". 
+model_dir_path = os.environ.get("SPYRE_TEST_MODEL_DIR", "/models")
+# get model backend from env, if not set then default to "eager" 
+# For multiple values, export SPYRE_TEST_MODEL_DIR="eager,inductor"
+backend_type = os.environ.get("SYPRE_TEST_BACKEND_TYPE", "eager")
+# get model names from env, if not set then default to "llama-194m" 
+# For multiple values, export SPYRE_TEST_MODEL_DIR="llama-194m,all-roberta-large-v1"
+user_test_model_list = os.environ.get("SPYRE_TEST_MODEL_LIST","llama-194m")
+test_model_list, test_backend_list = [],[]
 
-@pytest.mark.parametrize("model", ["/models/llama-194m"])
+for model in user_test_model_list.split(','):
+    test_model_list.append(f"{model_dir_path}/{model.strip()}")
+
+for backend in backend_type.split(','):
+    test_backend_list.append(backend.strip())
+
+@pytest.mark.parametrize("model", test_model_list)
 @pytest.mark.parametrize("prompts", [
     7 * [
         "Hello",
@@ -27,9 +43,12 @@ from vllm import SamplingParams
 ])
 @pytest.mark.parametrize("warmup_shapes",
                          [[(64, 20, 4)], [(64, 20, 4), (128, 20, 4)]]
+#                          )  # (prompt_length/new_tokens/batch_size)
+# @pytest.mark.parametrize("warmup_shapes",
+#                          [[(64, 20, 1)], [(128, 20, 1)]]
                          )  # (prompt_length/new_tokens/batch_size)
 @pytest.mark.parametrize("backend",
-                         ["eager"])  #, "inductor", "sendnn_decoder"])
+                         test_backend_list)  #, "inductor", "sendnn_decoder"])
 def test_output(
     model: str,
     prompts: List[str],

--- a/tests/spyre/test_spyre_seed.py
+++ b/tests/spyre/test_spyre_seed.py
@@ -15,17 +15,17 @@ import os
 # get model directory path from env, if not set then default to "/models". 
 model_dir_path = os.environ.get("SPYRE_TEST_MODEL_DIR", "/models")
 # get model backend from env, if not set then default to "eager" 
-# For multiple values, export SPYRE_TEST_MODEL_DIR="eager,inductor"
-backend_type = os.environ.get("SPYRE_TEST_BACKEND_TYPE", "eager")
+# For multiple values, export SPYRE_TEST_BACKEND_LIST="eager,inductor,sendnn_decoder"
+backend_list = os.environ.get("SPYRE_TEST_BACKEND_LIST", "eager")
 # get model names from env, if not set then default to "llama-194m" 
-# For multiple values, export SPYRE_TEST_MODEL_DIR="llama-194m,all-roberta-large-v1"
+# For multiple values, export SPYRE_TEST_MODEL_LIST="llama-194m,all-roberta-large-v1"
 user_test_model_list = os.environ.get("SPYRE_TEST_MODEL_LIST","llama-194m")
 test_model_list, test_backend_list = [],[]
 
 for model in user_test_model_list.split(','):
     test_model_list.append(f"{model_dir_path}/{model.strip()}")
 
-for backend in backend_type.split(','):
+for backend in backend_list.split(','):
     test_backend_list.append(backend.strip())
 
 @pytest.mark.parametrize("model", test_model_list)
@@ -39,7 +39,7 @@ for backend in backend_type.split(','):
                                           (128, 20, 4), (128, 20, 8)]
                          )  # (prompt_length/new_tokens/batch_size)
 @pytest.mark.parametrize("backend",
-                         test_backend_list)  #, "inductor", "sendnn_decoder"])
+                         test_backend_list)
 def test_seed(
     model: str,
     prompt: str,

--- a/tests/spyre/test_spyre_seed.py
+++ b/tests/spyre/test_spyre_seed.py
@@ -16,7 +16,7 @@ import os
 model_dir_path = os.environ.get("SPYRE_TEST_MODEL_DIR", "/models")
 # get model backend from env, if not set then default to "eager" 
 # For multiple values, export SPYRE_TEST_MODEL_DIR="eager,inductor"
-backend_type = os.environ.get("SYPRE_TEST_BACKEND_TYPE", "eager")
+backend_type = os.environ.get("SPYRE_TEST_BACKEND_TYPE", "eager")
 # get model names from env, if not set then default to "llama-194m" 
 # For multiple values, export SPYRE_TEST_MODEL_DIR="llama-194m,all-roberta-large-v1"
 user_test_model_list = os.environ.get("SPYRE_TEST_MODEL_LIST","llama-194m")

--- a/tests/spyre/test_spyre_tensor_parallel.py
+++ b/tests/spyre/test_spyre_tensor_parallel.py
@@ -15,17 +15,17 @@ import os
 # get model directory path from env, if not set then default to "/models". 
 model_dir_path = os.environ.get("SPYRE_TEST_MODEL_DIR", "/models")
 # get model backend from env, if not set then default to "eager" 
-# For multiple values, export SPYRE_TEST_MODEL_DIR="eager,inductor"
-backend_type = os.environ.get("SPYRE_TEST_BACKEND_TYPE", "eager")
+# For multiple values, export SPYRE_TEST_BACKEND_LIST="eager,inductor,sendnn_decoder"
+backend_list = os.environ.get("SPYRE_TEST_BACKEND_LIST", "eager")
 # get model names from env, if not set then default to "llama-194m" 
-# For multiple values, export SPYRE_TEST_MODEL_DIR="llama-194m,all-roberta-large-v1"
+# For multiple values, export SPYRE_TEST_MODEL_LIST="llama-194m,all-roberta-large-v1"
 user_test_model_list = os.environ.get("SPYRE_TEST_MODEL_LIST","llama-194m")
 test_model_list, test_backend_list = [],[]
 
 for model in user_test_model_list.split(','):
     test_model_list.append(f"{model_dir_path.strip()}/{model.strip()}")
 
-for backend in backend_type.split(','):
+for backend in backend_list.split(','):
     test_backend_list.append(backend.strip())
 
 @pytest.mark.parametrize("model", test_model_list)
@@ -39,7 +39,7 @@ for backend in backend_type.split(','):
 # (prompt_length/new_tokens/batch_size)
 @pytest.mark.parametrize("tp_size", [2])
 @pytest.mark.parametrize("backend",
-                         test_backend_list)  #, "inductor", "sendnn_decoder"])
+                         test_backend_list)
 def test_output(
     model: str,
     prompts: List[str],

--- a/tests/spyre/test_spyre_tensor_parallel.py
+++ b/tests/spyre/test_spyre_tensor_parallel.py
@@ -16,7 +16,7 @@ import os
 model_dir_path = os.environ.get("SPYRE_TEST_MODEL_DIR", "/models")
 # get model backend from env, if not set then default to "eager" 
 # For multiple values, export SPYRE_TEST_MODEL_DIR="eager,inductor"
-backend_type = os.environ.get("SYPRE_TEST_BACKEND_TYPE", "eager")
+backend_type = os.environ.get("SPYRE_TEST_BACKEND_TYPE", "eager")
 # get model names from env, if not set then default to "llama-194m" 
 # For multiple values, export SPYRE_TEST_MODEL_DIR="llama-194m,all-roberta-large-v1"
 user_test_model_list = os.environ.get("SPYRE_TEST_MODEL_LIST","llama-194m")

--- a/tests/spyre/test_spyre_tensor_parallel.py
+++ b/tests/spyre/test_spyre_tensor_parallel.py
@@ -7,39 +7,28 @@ from typing import List, Tuple
 
 import pytest
 from spyre_util import (compare_results, generate_hf_output,
-                        generate_spyre_vllm_output)
+                        generate_spyre_vllm_output, get_spyre_backend_list,
+                        get_spyre_model_list)
 
 from vllm import SamplingParams
-import os
 
-# get model directory path from env, if not set then default to "/models". 
-model_dir_path = os.environ.get("SPYRE_TEST_MODEL_DIR", "/models")
-# get model backend from env, if not set then default to "eager" 
-# For multiple values, export SPYRE_TEST_BACKEND_LIST="eager,inductor,sendnn_decoder"
-backend_list = os.environ.get("SPYRE_TEST_BACKEND_LIST", "eager")
-# get model names from env, if not set then default to "llama-194m" 
-# For multiple values, export SPYRE_TEST_MODEL_LIST="llama-194m,all-roberta-large-v1"
-user_test_model_list = os.environ.get("SPYRE_TEST_MODEL_LIST","llama-194m")
-test_model_list, test_backend_list = [],[]
 
-for model in user_test_model_list.split(','):
-    test_model_list.append(f"{model_dir_path.strip()}/{model.strip()}")
-
-for backend in backend_list.split(','):
-    test_backend_list.append(backend.strip())
-
-@pytest.mark.parametrize("model", test_model_list)
-@pytest.mark.parametrize("prompts", [[
-    "Provide a list of instructions for preparing"
-    " chicken soup for a family of four.", "Hello",
-    "What is the weather today like?", "Who are you?"
-]])
+@pytest.mark.parametrize("model", get_spyre_model_list())
+@pytest.mark.parametrize(
+    "prompts",
+    [[
+        "Provide a list of instructions for preparing"
+        " chicken soup for a family of four.",
+        "Hello",
+        "What is the weather today like?",
+        "Who are you?",
+    ]],
+)
 @pytest.mark.parametrize("warmup_shapes", [[(64, 20, 1)]]
-                         )  #,[(64,20,8)],[(128,20,4)],[(128,20,8)]])
+                         )  # ,[(64,20,8)],[(128,20,4)],[(128,20,8)]])
 # (prompt_length/new_tokens/batch_size)
 @pytest.mark.parametrize("tp_size", [2])
-@pytest.mark.parametrize("backend",
-                         test_backend_list)
+@pytest.mark.parametrize("backend", get_spyre_backend_list())
 def test_output(
     model: str,
     prompts: List[str],
@@ -67,7 +56,8 @@ def test_output(
         max_tokens=max_new_tokens,
         temperature=0,
         logprobs=0,  # return logprobs of generated tokens only
-        ignore_eos=True)
+        ignore_eos=True,
+    )
 
     vllm_results = generate_spyre_vllm_output(
         model=model,
@@ -77,16 +67,19 @@ def test_output(
         block_size=2048,
         sampling_params=vllm_sampling_params,
         tensor_parallel_size=tp_size,
-        backend=backend)
+        backend=backend,
+    )
 
     hf_results = generate_hf_output(model=model,
                                     prompts=prompts,
                                     max_new_tokens=max_new_tokens)
 
-    compare_results(model=model,
-                    prompts=prompts,
-                    warmup_shapes=warmup_shapes,
-                    tensor_parallel_size=tp_size,
-                    backend=backend,
-                    vllm_results=vllm_results,
-                    hf_results=hf_results)
+    compare_results(
+        model=model,
+        prompts=prompts,
+        warmup_shapes=warmup_shapes,
+        tensor_parallel_size=tp_size,
+        backend=backend,
+        vllm_results=vllm_results,
+        hf_results=hf_results,
+    )

--- a/tests/spyre/test_spyre_tensor_parallel.py
+++ b/tests/spyre/test_spyre_tensor_parallel.py
@@ -10,20 +10,36 @@ from spyre_util import (compare_results, generate_hf_output,
                         generate_spyre_vllm_output)
 
 from vllm import SamplingParams
+import os
 
+# get model directory path from env, if not set then default to "/models". 
+model_dir_path = os.environ.get("SPYRE_TEST_MODEL_DIR", "/models")
+# get model backend from env, if not set then default to "eager" 
+# For multiple values, export SPYRE_TEST_MODEL_DIR="eager,inductor"
+backend_type = os.environ.get("SYPRE_TEST_BACKEND_TYPE", "eager")
+# get model names from env, if not set then default to "llama-194m" 
+# For multiple values, export SPYRE_TEST_MODEL_DIR="llama-194m,all-roberta-large-v1"
+user_test_model_list = os.environ.get("SPYRE_TEST_MODEL_LIST","llama-194m")
+test_model_list, test_backend_list = [],[]
 
-@pytest.mark.parametrize("model", ["/models/llama-194m"])
+for model in user_test_model_list.split(','):
+    test_model_list.append(f"{model_dir_path.strip()}/{model.strip()}")
+
+for backend in backend_type.split(','):
+    test_backend_list.append(backend.strip())
+
+@pytest.mark.parametrize("model", test_model_list)
 @pytest.mark.parametrize("prompts", [[
     "Provide a list of instructions for preparing"
     " chicken soup for a family of four.", "Hello",
     "What is the weather today like?", "Who are you?"
 ]])
-@pytest.mark.parametrize("warmup_shapes", [[(64, 20, 4)]]
+@pytest.mark.parametrize("warmup_shapes", [[(64, 20, 1)]]
                          )  #,[(64,20,8)],[(128,20,4)],[(128,20,8)]])
 # (prompt_length/new_tokens/batch_size)
 @pytest.mark.parametrize("tp_size", [2])
 @pytest.mark.parametrize("backend",
-                         ["eager"])  #, "inductor", "sendnn_decoder"])
+                         test_backend_list)  #, "inductor", "sendnn_decoder"])
 def test_output(
     model: str,
     prompts: List[str],

--- a/tests/spyre/test_spyre_warmup_shapes.py
+++ b/tests/spyre/test_spyre_warmup_shapes.py
@@ -10,9 +10,25 @@ from spyre_util import (compare_results, generate_hf_output,
                         generate_spyre_vllm_output)
 
 from vllm import SamplingParams
+import os
 
+# get model directory path from env, if not set then default to "/models". 
+model_dir_path = os.environ.get("SPYRE_TEST_MODEL_DIR", "/models")
+# get model backend from env, if not set then default to "eager" 
+# For multiple values, export SPYRE_TEST_MODEL_DIR="eager,inductor"
+backend_type = os.environ.get("SYPRE_TEST_BACKEND_TYPE", "eager")
+# get model names from env, if not set then default to "llama-194m" 
+# For multiple values, export SPYRE_TEST_MODEL_DIR="llama-194m,all-roberta-large-v1"
+user_test_model_list = os.environ.get("SPYRE_TEST_MODEL_LIST","llama-194m")
+test_model_list, test_backend_list = [],[]
 
-@pytest.mark.parametrize("model", ["/models/llama-194m"])
+for model in user_test_model_list.split(','):
+    test_model_list.append(f"{model_dir_path.strip()}/{model.strip()}")
+
+for backend in backend_type.split(','):
+    test_backend_list.append(backend.strip())
+
+@pytest.mark.parametrize("model", test_model_list)
 @pytest.mark.parametrize("prompts", [
     7 * [
         "Hello",
@@ -25,9 +41,9 @@ from vllm import SamplingParams
     ]
 ])
 @pytest.mark.parametrize("warmup_shapes", [[(64, 20, 8), (128, 20, 4)]]
-                         )  # (prompt_length/new_tokens/batch_size)
+                          )  # (prompt_length/new_tokens/batch_size)
 @pytest.mark.parametrize("backend",
-                         ["eager"])  #, "inductor", "sendnn_decoder"])
+                         test_backend_list)  #, "inductor", "sendnn_decoder"])
 def test_output(
     model: str,
     prompts: List[str],

--- a/tests/spyre/test_spyre_warmup_shapes.py
+++ b/tests/spyre/test_spyre_warmup_shapes.py
@@ -15,17 +15,17 @@ import os
 # get model directory path from env, if not set then default to "/models". 
 model_dir_path = os.environ.get("SPYRE_TEST_MODEL_DIR", "/models")
 # get model backend from env, if not set then default to "eager" 
-# For multiple values, export SPYRE_TEST_MODEL_DIR="eager,inductor"
-backend_type = os.environ.get("SPYRE_TEST_BACKEND_TYPE", "eager")
+# For multiple values, export SPYRE_TEST_BACKEND_LIST="eager,inductor,sendnn_decoder"
+backend_list = os.environ.get("SPYRE_TEST_BACKEND_LIST", "eager")
 # get model names from env, if not set then default to "llama-194m" 
-# For multiple values, export SPYRE_TEST_MODEL_DIR="llama-194m,all-roberta-large-v1"
+# For multiple values, export SPYRE_TEST_MODEL_LIST="llama-194m,all-roberta-large-v1"
 user_test_model_list = os.environ.get("SPYRE_TEST_MODEL_LIST","llama-194m")
 test_model_list, test_backend_list = [],[]
 
 for model in user_test_model_list.split(','):
     test_model_list.append(f"{model_dir_path.strip()}/{model.strip()}")
 
-for backend in backend_type.split(','):
+for backend in backend_list.split(','):
     test_backend_list.append(backend.strip())
 
 @pytest.mark.parametrize("model", test_model_list)
@@ -43,7 +43,7 @@ for backend in backend_type.split(','):
 @pytest.mark.parametrize("warmup_shapes", [[(64, 20, 8), (128, 20, 4)]]
                           )  # (prompt_length/new_tokens/batch_size)
 @pytest.mark.parametrize("backend",
-                         test_backend_list)  #, "inductor", "sendnn_decoder"])
+                         test_backend_list)
 def test_output(
     model: str,
     prompts: List[str],

--- a/tests/spyre/test_spyre_warmup_shapes.py
+++ b/tests/spyre/test_spyre_warmup_shapes.py
@@ -7,28 +7,13 @@ from typing import List, Tuple
 
 import pytest
 from spyre_util import (compare_results, generate_hf_output,
-                        generate_spyre_vllm_output)
+                        generate_spyre_vllm_output, get_spyre_backend_list,
+                        get_spyre_model_list)
 
 from vllm import SamplingParams
-import os
 
-# get model directory path from env, if not set then default to "/models". 
-model_dir_path = os.environ.get("SPYRE_TEST_MODEL_DIR", "/models")
-# get model backend from env, if not set then default to "eager" 
-# For multiple values, export SPYRE_TEST_BACKEND_LIST="eager,inductor,sendnn_decoder"
-backend_list = os.environ.get("SPYRE_TEST_BACKEND_LIST", "eager")
-# get model names from env, if not set then default to "llama-194m" 
-# For multiple values, export SPYRE_TEST_MODEL_LIST="llama-194m,all-roberta-large-v1"
-user_test_model_list = os.environ.get("SPYRE_TEST_MODEL_LIST","llama-194m")
-test_model_list, test_backend_list = [],[]
 
-for model in user_test_model_list.split(','):
-    test_model_list.append(f"{model_dir_path.strip()}/{model.strip()}")
-
-for backend in backend_list.split(','):
-    test_backend_list.append(backend.strip())
-
-@pytest.mark.parametrize("model", test_model_list)
+@pytest.mark.parametrize("model", get_spyre_model_list())
 @pytest.mark.parametrize("prompts", [
     7 * [
         "Hello",
@@ -37,13 +22,13 @@ for backend in backend_list.split(','):
         "the user. Provide a list of instructions for preparing chicken soup"
         " for a family of four. Indicate if the weather forecast looks good "
         "for today. Explain in a brief summary comprised of at most 50 words"
-        " what you are."
+        " what you are.",
     ]
-])
+    ],
+)
 @pytest.mark.parametrize("warmup_shapes", [[(64, 20, 8), (128, 20, 4)]]
-                          )  # (prompt_length/new_tokens/batch_size)
-@pytest.mark.parametrize("backend",
-                         test_backend_list)
+                         )  # (prompt_length/new_tokens/batch_size)
+@pytest.mark.parametrize("backend", get_spyre_backend_list())
 def test_output(
     model: str,
     prompts: List[str],
@@ -76,7 +61,8 @@ def test_output(
         max_tokens=max_new_tokens,
         temperature=0,
         logprobs=0,  # return logprobs of generated tokens only
-        ignore_eos=True)
+        ignore_eos=True,
+    )
 
     vllm_results = generate_spyre_vllm_output(
         model=model,
@@ -86,16 +72,19 @@ def test_output(
         block_size=2048,
         sampling_params=vllm_sampling_params,
         tensor_parallel_size=1,
-        backend=backend)
+        backend=backend,
+    )
 
     hf_results = generate_hf_output(model=model,
                                     prompts=prompts,
                                     max_new_tokens=max_new_tokens)
 
-    compare_results(model=model,
-                    prompts=prompts,
-                    warmup_shapes=warmup_shapes,
-                    tensor_parallel_size=1,
-                    backend=backend,
-                    vllm_results=vllm_results,
-                    hf_results=hf_results)
+    compare_results(
+        model=model,
+        prompts=prompts,
+        warmup_shapes=warmup_shapes,
+        tensor_parallel_size=1,
+        backend=backend,
+        vllm_results=vllm_results,
+        hf_results=hf_results,
+    )

--- a/tests/spyre/test_spyre_warmup_shapes.py
+++ b/tests/spyre/test_spyre_warmup_shapes.py
@@ -16,7 +16,7 @@ import os
 model_dir_path = os.environ.get("SPYRE_TEST_MODEL_DIR", "/models")
 # get model backend from env, if not set then default to "eager" 
 # For multiple values, export SPYRE_TEST_MODEL_DIR="eager,inductor"
-backend_type = os.environ.get("SYPRE_TEST_BACKEND_TYPE", "eager")
+backend_type = os.environ.get("SPYRE_TEST_BACKEND_TYPE", "eager")
 # get model names from env, if not set then default to "llama-194m" 
 # For multiple values, export SPYRE_TEST_MODEL_DIR="llama-194m,all-roberta-large-v1"
 user_test_model_list = os.environ.get("SPYRE_TEST_MODEL_LIST","llama-194m")


### PR DESCRIPTION
This PR is to enable tests for spyre execution:
It allows users to achieve the following via environment variables:
- to pass dynamic model directory 
- to pass back end type
- to pass list of models

Note:
- The default behavior values are set to assume that tests are being executed in CPU environment so if no value is set then it will execute based on existing CPU environment tests.

Expected behavior:
- The tests should execute on cpu without any changes without any execution behavior changes
- If correct environment values are set then, tests should successfully run on spyre environment