### PR TITLE
Ysc pluggable scheduler

### DIFF
--- a/vllm/config.py
+++ b/vllm/config.py
@@ -1486,7 +1486,6 @@ class SchedulerConfig:
                 self.max_num_batched_tokens)
 
         self.chunked_prefill_enabled = self.enable_chunked_prefill
-        self.spyre_warmup_shapes = None
         self._verify_args()
 
     def _verify_args(self) -> None:

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -1258,7 +1258,7 @@ class ParallelConfig:
     # will be determined based on the platform.
     worker_cls: str = "auto"
     sd_worker_cls: str = "auto"
-    scheduler_cls: str = "auto"
+    scheduler_cls: str = "vllm.core.scheduler.Scheduler"
 
     world_size: int = field(init=False)
 

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -3,7 +3,6 @@ import copy
 import enum
 import hashlib
 import json
-import operator
 import sys
 import warnings
 from contextlib import contextmanager
@@ -1487,41 +1486,7 @@ class SchedulerConfig:
                 self.max_num_batched_tokens)
 
         self.chunked_prefill_enabled = self.enable_chunked_prefill
-        from vllm.platforms import current_platform
-        self.spyre_scheduling_enabled = current_platform.get_device_name(
-        ) == "spyre"
-        if self.spyre_scheduling_enabled:
-            # load warmup shapes and sort by "speed"
-            wup_prompt_lens = envs.VLLM_SPYRE_WARMUP_PROMPT_LENS or []
-            wup_batch_sizes = envs.VLLM_SPYRE_WARMUP_BATCH_SIZES or []
-            if len(wup_prompt_lens) != len(wup_batch_sizes):
-                raise RuntimeError(
-                    "The lists in VLLM_SPYRE_WARMUP_PROMPT_LENS and "
-                    "VLLM_SPYRE_WARMUP_BATCH_SIZES must have equal length")
-            if self.runner_type == "pooling":
-                wup_new_tokens = [0] * len(wup_prompt_lens)
-            else:
-                wup_new_tokens = envs.VLLM_SPYRE_WARMUP_NEW_TOKENS or []
-                if len(wup_new_tokens) != len(wup_prompt_lens):
-                    raise RuntimeError(
-                        "The lists in VLLM_SPYRE_WARMUP_PROMPT_LENS and "
-                        "VLLM_SPYRE_WARMUP_NEW_TOKENS must have equal length")
-
-            print("[SchedulerConfig] VLLM_SPYRE_WARMUP_PROMPT_LENS =",
-                  wup_prompt_lens)
-            print("[SchedulerConfig] VLLM_SPYRE_WARMUP_NEW_TOKENS =",
-                  wup_new_tokens)
-            print("[SchedulerConfig] VLLM_SPYRE_WARMUP_BATCH_SIZES =",
-                  wup_batch_sizes)
-
-            self.spyre_warmup_shapes = tuple(
-                sorted([{
-                    'prompt_length': pl,
-                    'new_tokens': nt,
-                    'batch_size': bs
-                } for pl, nt, bs in zip(wup_prompt_lens, wup_new_tokens,
-                                        wup_batch_sizes)],
-                       key=operator.itemgetter('batch_size', 'prompt_length')))
+        self.spyre_warmup_shapes = None
         self._verify_args()
 
     def _verify_args(self) -> None:

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -1258,6 +1258,7 @@ class ParallelConfig:
     # will be determined based on the platform.
     worker_cls: str = "auto"
     sd_worker_cls: str = "auto"
+    scheduler_cls: str = "auto"
 
     world_size: int = field(init=False)
 

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -1257,7 +1257,6 @@ class ParallelConfig:
     # will be determined based on the platform.
     worker_cls: str = "auto"
     sd_worker_cls: str = "auto"
-    scheduler_cls: str = "vllm.core.scheduler.Scheduler"
 
     world_size: int = field(init=False)
 
@@ -1427,6 +1426,9 @@ class SchedulerConfig:
     policy: str = "fcfs"
 
     chunked_prefill_enabled: bool = field(init=False)
+
+    # scheduler class or path
+    scheduler_cls: Union[str, Type[object]] = "vllm.core.scheduler.Scheduler"
 
     def compute_hash(self) -> str:
         """

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -345,10 +345,6 @@ class LLMEngine:
         # NOTE: the cache_config here have been updated with the numbers of
         # GPU and CPU blocks, which are profiled in the distributed executor.
 
-        # use generic Scheduler if no platform specific Scheduler specified
-        if self.vllm_config.parallel_config.scheduler_cls == "auto":
-            self.vllm_config.parallel_config.scheduler_cls = \
-            "vllm.core.scheduler.Scheduler"
         Scheduler = resolve_obj_by_qualname(
             self.vllm_config.parallel_config.scheduler_cls)
         self.scheduler = [

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -345,8 +345,11 @@ class LLMEngine:
         # NOTE: the cache_config here have been updated with the numbers of
         # GPU and CPU blocks, which are profiled in the distributed executor.
 
-        Scheduler = resolve_obj_by_qualname(
-            self.vllm_config.parallel_config.scheduler_cls)
+        if isinstance(self.vllm_config.scheduler_config.scheduler_cls, str):
+            Scheduler = resolve_obj_by_qualname(
+                self.vllm_config.scheduler_config.scheduler_cls)
+        else:
+            Scheduler = self.vllm_config.scheduler_config.scheduler_cls
         self.scheduler = [
             Scheduler(
                 self.scheduler_config, self.cache_config, self.lora_config,

--- a/vllm/envs.py
+++ b/vllm/envs.py
@@ -67,9 +67,6 @@ if TYPE_CHECKING:
     VLLM_USE_TRITON_AWQ: bool = False
     VLLM_ALLOW_RUNTIME_LORA_UPDATING: bool = False
     VLLM_SKIP_P2P_CHECK: bool = False
-    VLLM_SPYRE_WARMUP_PROMPT_LENS: Optional[List[int]] = None
-    VLLM_SPYRE_WARMUP_NEW_TOKENS: Optional[List[int]] = None
-    VLLM_SPYRE_WARMUP_BATCH_SIZES: Optional[List[int]] = None
     VLLM_DISABLED_KERNELS: List[str] = []
     VLLM_USE_V1: bool = False
     VLLM_ENABLE_V1_MULTIPROCESSING: bool = True
@@ -470,30 +467,6 @@ environment_variables: Dict[str, Callable[[], Any]] = {
     lambda: float(os.getenv("VLLM_LOG_BATCHSIZE_INTERVAL", "-1")),
     "VLLM_DISABLE_COMPILE_CACHE":
     lambda: bool(int(os.getenv("VLLM_DISABLE_COMPILE_CACHE", "0"))),
-
-    # Defines the prompt lengths the Spyre accelerator should be prepared
-    # for, formatted as comma separated list.
-    "VLLM_SPYRE_WARMUP_PROMPT_LENS":
-    lambda: [
-        int(p) for p in os.getenv(key='VLLM_SPYRE_WARMUP_PROMPT_LENS',
-                                  default='64').split(',')
-    ],
-
-    # Defines the max output tokens the Spyre accelerator should be prepared
-    # for, formatted as comma separated list.
-    "VLLM_SPYRE_WARMUP_NEW_TOKENS":
-    lambda: [
-        int(d) for d in os.getenv(key='VLLM_SPYRE_WARMUP_NEW_TOKENS',
-                                  default='20').split(',')
-    ],
-
-    # Defines the batch sizes the Spyre accelerator should be prepared
-    # for, formatted as comma separated list.
-    "VLLM_SPYRE_WARMUP_BATCH_SIZES":
-    lambda: [
-        int(b) for b in os.getenv(key='VLLM_SPYRE_WARMUP_BATCH_SIZES',
-                                  default='1').split(',')
-    ],
 }
 
 # end-env-vars-definition


### PR DESCRIPTION
This PR moves the (spyre specific) scheduler class into the plugin repo `vllm-spyre`.
it goes along with this ->[PR](https://github.com/IBM/vllm-spyre/pull/4)<- in the `vllm-spyre` repository 

Changes:
- `vllm/config.py`: introducing new variable `scheduler_cls` for class `SchedulerConfig` (can be a path (str) or a class directly) and removing spyre specific code to 'load warmup shapes and sort by "speed"' (moved to `vllm-spyre`)
- `vllm/engine/llm_engine.py`: importing `Scheduler` based on `vllm_config.scheduler_config.scheduler_cls` 
- `vllm/core/scheduler.py`: removing all spyre specific code from the scheduler logic
- `vllm/envs.py`: removing all spyre related env variables (moved to `vllm-spyre`)
- remove the variable: `SchedulerConfig.spyre_warmup_shapes` in `vllm/vllm.config.py`