### PR TITLE
repositioning fixes, tensor shape mismatch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -218,3 +218,5 @@ csrc/moe/marlin_moe_wna16/kernel_*
 
 # Ignore ep_kernels_workspace folder
 ep_kernels_workspace/
+
+dev/


### PR DESCRIPTION
Accuracy numbers were wrong on our evals, now they're good again.

The issue was in `_perform_repositioning` in `gpu_model_runner.py` in the v1 API.

Basically if there's not too many repositioning requests, the vectors from different layers of the model are concatenated along the batch dimension before RoPE is applied twice to them.

Problem was: I forgot that the "positions" tensor telling the RoPE function what positional encodings to apply to the vectors needs to be repeated as its batch size does not match the big tensor's. Normally PyTorch would broadcast that tensor, but the RoPE function calls the `.view` function on the key vectors such that this is a wrong assumption.